### PR TITLE
feat: history modal with delete and compare accuracy fix

### DIFF
--- a/frontend/src/app/api/history/[runId]/route.ts
+++ b/frontend/src/app/api/history/[runId]/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+
+const OUTPUT_DIR = path.join(process.cwd(), "public", "output");
+
+interface DeleteResponse {
+  success: boolean;
+  error?: string;
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ runId: string }> }
+): Promise<NextResponse<DeleteResponse>> {
+  const { runId } = await params;
+
+  // Validate runId is a 10-digit timestamp
+  if (!/^\d{10}$/.test(runId)) {
+    return NextResponse.json(
+      { success: false, error: "Invalid run ID format" },
+      { status: 400 }
+    );
+  }
+
+  const runDir = path.join(OUTPUT_DIR, runId);
+
+  try {
+    // Check if directory exists
+    if (!fs.existsSync(runDir)) {
+      return NextResponse.json(
+        { success: false, error: "Run not found" },
+        { status: 404 }
+      );
+    }
+
+    // Remove the entire run directory
+    fs.rmSync(runDir, { recursive: true, force: true });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Failed to delete run:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to delete run" },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -487,6 +487,7 @@ function HomeContent() {
                         }
                       }}
                       placeholder={runId}
+                      maxLength={50}
                       className={`bg-transparent border-b focus:outline-none px-1 min-w-40 ${
                         renameError
                           ? "border-red-500 focus:border-red-500"

--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -38,6 +38,8 @@ export function ModelSelector({ value, onChange, dataset, disabled }: ModelSelec
   const [isHistoryOpen, setIsHistoryOpen] = useState(false);
   const [history, setHistory] = useState<HistoryRun[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
   const router = useRouter();
 
   const options = Object.values(MODELS).map((model) => ({
@@ -61,12 +63,67 @@ export function ModelSelector({ value, onChange, dataset, disabled }: ModelSelec
   useEffect(() => {
     if (isHistoryOpen) {
       fetchHistory();
+      setDeleteConfirmId(null);
     }
   }, [isHistoryOpen, fetchHistory]);
 
   const handleRunClick = (runId: string) => {
     setIsHistoryOpen(false);
     router.push(`/?run_id=${runId}`);
+  };
+
+  const handleDeleteClick = (e: React.MouseEvent, run: HistoryRun) => {
+    e.stopPropagation();
+
+    // If run has a name, show confirmation
+    if (run.name) {
+      setDeleteConfirmId(run.runId);
+    } else {
+      // No name - delete immediately
+      performDelete(run.runId);
+    }
+  };
+
+  const handleCancelDelete = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setDeleteConfirmId(null);
+  };
+
+  const handleConfirmDelete = (e: React.MouseEvent, runId: string) => {
+    e.stopPropagation();
+    performDelete(runId);
+  };
+
+  const performDelete = async (runId: string) => {
+    setDeletingId(runId);
+    setDeleteConfirmId(null);
+
+    // Optimistic update - remove from UI immediately
+    const previousHistory = [...history];
+    setHistory(history.filter(run => run.runId !== runId));
+
+    try {
+      const res = await fetch(`/api/history/${runId}`, { method: 'DELETE' });
+      const data = await res.json();
+
+      if (!data.success) {
+        // Restore on failure
+        setHistory(previousHistory);
+      }
+    } catch {
+      // Restore on error
+      setHistory(previousHistory);
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const getAccuracyColor = (accuracy: number) => {
+    if (accuracy >= 0.9) return 'text-green-600';
+    if (accuracy >= 0.8) return 'text-yellow-500';
+    if (accuracy >= 0.7) return 'text-orange-500';
+    if (accuracy >= 0.5) return 'text-red-600';
+    return 'text-blue-900';
   };
 
   return (
@@ -93,6 +150,8 @@ export function ModelSelector({ value, onChange, dataset, disabled }: ModelSelec
         isOpen={isHistoryOpen}
         onClose={() => setIsHistoryOpen(false)}
         title={`${MODELS[value].name} History - ${dataset}`}
+        maxWidth="lg"
+        fitContent
       >
         {isLoading ? (
           <div className="flex justify-center py-8">
@@ -103,32 +162,91 @@ export function ModelSelector({ value, onChange, dataset, disabled }: ModelSelec
             No history found
           </div>
         ) : (
-          <div className="space-y-1">
-            {history.map((run) => {
-              const accuracyColor = run.accuracy >= 0.9
-                ? 'text-green-600'
-                : run.accuracy >= 0.8
-                  ? 'text-yellow-500'
-                  : run.accuracy >= 0.7
-                    ? 'text-orange-500'
-                    : run.accuracy >= 0.5
-                      ? 'text-red-600'
-                      : 'text-blue-900';
-              return (
-                <button
-                  key={run.runId}
-                  onClick={() => handleRunClick(run.runId)}
-                  className="w-full flex items-center justify-between px-3 py-2 rounded hover:bg-gray-50 transition-colors"
-                >
-                  <span className="font-mono text-sm text-gray-700">
-                    {run.name ? run.name.replace(/_/g, " ") : run.runId}
-                  </span>
-                  <span className={`font-semibold ${accuracyColor}`}>{(run.accuracy * 100).toFixed(2)}%</span>
-                  <span className="text-sm text-gray-400">{formatTimeAgo(run.timestamp)}</span>
-                </button>
-              );
-            })}
-          </div>
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-gray-200 text-xs font-medium text-gray-500">
+                <th className="text-left px-3 py-2 font-medium">Name/ID</th>
+                <th className="text-right px-3 py-2 font-medium w-[70px]">Accuracy</th>
+                <th className="text-right px-3 py-2 font-medium w-[90px]">Time</th>
+                <th className="text-center px-1 py-2 font-medium w-[44px]"><span className="sr-only">Delete</span></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {history.map((run) => {
+                const isConfirming = deleteConfirmId === run.runId;
+                const isDeleting = deletingId === run.runId;
+
+                return (
+                  <tr
+                    key={run.runId}
+                    onClick={() => !isConfirming && handleRunClick(run.runId)}
+                    className={`transition-colors ${
+                      isConfirming ? 'bg-red-50' : 'hover:bg-gray-50 cursor-pointer'
+                    }`}
+                  >
+                    {/* Name/ID Column */}
+                    <td className="px-3 py-2 font-mono text-sm text-gray-700 whitespace-nowrap">
+                      {run.name ? run.name.replace(/_/g, " ") : run.runId}
+                    </td>
+
+                    {/* Accuracy Column */}
+                    <td className={`px-3 py-2 text-right font-semibold ${getAccuracyColor(run.accuracy)}`}>
+                      {(run.accuracy * 100).toFixed(2)}%
+                    </td>
+
+                    {isConfirming ? (
+                      /* Confirmation UI - spans Time and Delete columns */
+                      <td colSpan={2} className="px-3 py-2">
+                        <div className="flex items-center justify-end gap-2">
+                          <span className="text-sm text-red-600">Delete?</span>
+                          <button
+                            type="button"
+                            onClick={handleCancelDelete}
+                            className="px-2 py-1 text-xs font-medium text-gray-600 bg-gray-100 rounded hover:bg-gray-200"
+                          >
+                            Cancel
+                          </button>
+                          <button
+                            type="button"
+                            onClick={(e) => handleConfirmDelete(e, run.runId)}
+                            className="px-2 py-1 text-xs font-medium text-white bg-red-600 rounded hover:bg-red-700"
+                          >
+                            Confirm
+                          </button>
+                        </div>
+                      </td>
+                    ) : (
+                      <>
+                        {/* Time Column */}
+                        <td className="px-3 py-2 text-right text-sm text-gray-400 whitespace-nowrap">
+                          {formatTimeAgo(run.timestamp)}
+                        </td>
+
+                        {/* Delete Column */}
+                        <td className="px-1 py-2 text-center">
+                          <button
+                            type="button"
+                            onClick={(e) => handleDeleteClick(e, run)}
+                            disabled={isDeleting}
+                            className="p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded transition-colors disabled:opacity-50"
+                            title="Delete run"
+                          >
+                            {isDeleting ? (
+                              <div className="animate-spin h-4 w-4 border-2 border-red-600 border-t-transparent rounded-full" />
+                            ) : (
+                              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                              </svg>
+                            )}
+                          </button>
+                        </td>
+                      </>
+                    )}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
         )}
       </Modal>
     </>

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -7,9 +7,23 @@ interface ModalProps {
   onClose: () => void;
   title: string;
   children: React.ReactNode;
+  maxWidth?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl' | '6xl';
+  fitContent?: boolean;
 }
 
-export function Modal({ isOpen, onClose, title, children }: ModalProps) {
+const maxWidthClasses = {
+  sm: 'max-w-sm',
+  md: 'max-w-md',
+  lg: 'max-w-lg',
+  xl: 'max-w-xl',
+  '2xl': 'max-w-2xl',
+  '3xl': 'max-w-3xl',
+  '4xl': 'max-w-4xl',
+  '5xl': 'max-w-5xl',
+  '6xl': 'max-w-6xl',
+};
+
+export function Modal({ isOpen, onClose, title, children, maxWidth = '6xl', fitContent = false }: ModalProps) {
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -42,13 +56,13 @@ export function Modal({ isOpen, onClose, title, children }: ModalProps) {
       />
 
       {/* Modal container */}
-      <div className="relative bg-white rounded-lg shadow-xl w-full max-w-6xl max-h-[90vh] m-4 flex flex-col">
+      <div className={`relative bg-white rounded-lg shadow-xl ${fitContent ? '' : `w-full ${maxWidthClasses[maxWidth]}`} max-h-[90vh] m-4 flex flex-col`}>
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
-          <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 shrink-0">
+          <h2 className="text-lg font-semibold text-gray-900 whitespace-nowrap">{title}</h2>
           <button
             onClick={onClose}
-            className="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100"
+            className="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 ml-4"
             aria-label="Close modal"
           >
             <svg
@@ -68,7 +82,7 @@ export function Modal({ isOpen, onClose, title, children }: ModalProps) {
         </div>
 
         {/* Body */}
-        <div className="flex-1 overflow-auto p-6">
+        <div className={`flex-1 p-6 ${fitContent ? '' : 'overflow-auto'}`}>
           {children}
         </div>
       </div>

--- a/specs/frontend/Form.md
+++ b/specs/frontend/Form.md
@@ -24,13 +24,7 @@ Form components for selecting dataset, model, and configuring training parameter
 ### ModelSelector
 - Dropdown with model options
 - **History button**: Next to the "Model" label, displays "History" text button
-  - Opens modal showing previous training runs for the selected model
-  - Scans `frontend/public/output/<timestamp>/<model>_<dataset>_<score>[_<name>].id` files
-  - Each run displays as: "Timestamp - Accuracy% - timeago" (e.g., "1706540123 - 98.00% - 2 hours ago")
-  - If run has a custom name, displays as: "Name - Accuracy% - timeago" (e.g., "my experiment - 98.00% - 2 hours ago")
-  - Names are stored with underscores but displayed with spaces
-  - Clicking a run navigates to `/?run_id=<timestamp>`
-  - Shows "No history found" when no runs exist
+  - Opens HistoryModal (see [HistoryModal spec](HistoryModal.md))
 - Props: `value`, `onChange`, `disabled`
 
 ### ParamsTabs
@@ -148,3 +142,4 @@ Columns displayed as a list of checkboxes. User can deselect columns to exclude 
 ## Related specs
 - [frontend/Layout](Layout.md) - Page structure
 - [frontend/Output](Output.md) - Results display
+- [frontend/HistoryModal](HistoryModal.md) - History modal for viewing/deleting runs

--- a/specs/frontend/HistoryModal.md
+++ b/specs/frontend/HistoryModal.md
@@ -1,0 +1,207 @@
+# History Modal
+
+## Overview
+Modal dialog displaying previous training runs for the selected model, with the ability to navigate to a run or delete it. Features a well-aligned table layout with consistent column widths.
+
+## Requirements
+- Modal opens from the "History" button in ModelSelector
+- Displays runs in a proper table with consistent column alignment
+- Delete functionality with conditional confirmation based on run name
+- Clicking a run row navigates to `/?run_id=<timestamp>`
+- Shows "No history found" when no runs exist
+
+## Layout
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ History - Decision Tree                                       [X]  │
+├─────────────────────────────────────────────────────────────────────┤
+│ ┌─────────────────────────────────────────────────────────────────┐ │
+│ │ Name/ID          │ Accuracy  │ Time           │ Delete         │ │
+│ ├─────────────────────────────────────────────────────────────────┤ │
+│ │ my experiment    │ 98.00%    │ 2 hours ago    │        [🗑️]    │ │
+│ │ 1706540123       │ 96.50%    │ 1 day ago      │        [🗑️]    │ │
+│ │ baseline run     │ 95.00%    │ 3 days ago     │        [🗑️]    │ │
+│ └─────────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Table Structure
+
+### Columns
+| Column | Content | Width | Alignment |
+|--------|---------|-------|-----------|
+| Name/ID | Run name (spaces) or timestamp ID | auto (content-based) | left |
+| Accuracy | Accuracy percentage (e.g., "98.00%") | fixed ~70px | right |
+| Time | Relative time (e.g., "2 hours ago") | fixed ~90px | right |
+| Delete | Delete button (trash icon) | fixed ~44px | center |
+
+### Name/ID Display
+- **No truncation**: Names are displayed in full, never cropped with ellipsis
+- **No-wrap**: Text stays on a single line (`white-space: nowrap`)
+- **Max length**: Names are limited to 50 characters at input time (see Layout spec)
+- **Modal width**: Modal expands to fit content, with a reasonable max-width
+
+### Implementation Options
+Use one of these approaches for consistent alignment:
+
+**Option A: CSS Grid**
+```css
+.history-table {
+  display: grid;
+  grid-template-columns: auto 70px 90px 44px;
+}
+.history-name {
+  white-space: nowrap;
+}
+```
+
+**Option B: HTML Table**
+```html
+<table>
+  <colgroup>
+    <col style="width: auto" />
+    <col style="width: 70px" />
+    <col style="width: 90px" />
+    <col style="width: 44px" />
+  </colgroup>
+</table>
+```
+
+## Delete Behavior
+
+### One-Click Delete (Default)
+Runs **without** a custom name are deleted immediately with one click:
+- `.id` filename format: `<model>_<dataset>_<score>.id`
+- Example: `tree_Iris_100000.id`
+- Click delete button → immediately removes the run directory
+- No confirmation dialog
+
+### Confirmation Delete (Named Runs)
+Runs **with** a custom name show a confirmation dialog before deleting:
+- `.id` filename format: `<model>_<dataset>_<score>_<name>.id`
+- Example: `tree_Iris_100000_my_experiment.id`
+- Click delete button → shows inline confirmation
+- User must click "Confirm" to delete
+
+### Inline Confirmation
+When deleting a named run, the row transforms to show confirmation:
+
+```
+│ my experiment    │ 98.00%    │ Delete this run?  [Cancel] [Confirm] │
+```
+
+- "Delete this run?" text replaces the time column
+- Cancel button restores the normal row
+- Confirm button deletes the run
+- Only one row can be in confirmation state at a time
+
+### Delete API
+**Endpoint:** `DELETE /api/history/<runId>`
+
+**Response:**
+```json
+{
+  "success": true
+}
+```
+
+**Error Response:**
+```json
+{
+  "success": false,
+  "error": "Run not found"
+}
+```
+
+**Backend Action:**
+- Removes the entire run directory: `frontend/public/output/<runId>/`
+- Returns error if directory doesn't exist
+
+## State Management
+
+```typescript
+interface HistoryModalState {
+  isOpen: boolean;
+  runs: HistoryRun[];
+  isLoading: boolean;
+  deleteConfirmId: string | null;  // Run ID currently showing confirmation
+  isDeleting: string | null;       // Run ID currently being deleted
+}
+
+interface HistoryRun {
+  runId: string;
+  name: string | null;      // Custom name if exists
+  accuracy: number;
+  timestamp: number;        // Unix timestamp for time calculation
+  hasName: boolean;         // Whether run has a custom name (for delete behavior)
+}
+```
+
+## Row Interaction
+
+### Click Behavior
+- Clicking anywhere on a row (except delete button) navigates to that run
+- Row has hover state to indicate clickability
+- Cursor changes to pointer on hover
+
+### Delete Button
+- Positioned on the right side of each row
+- Shows trash icon
+- Prevents click propagation (doesn't trigger row navigation)
+- Shows loading spinner while delete is in progress
+
+## Empty State
+
+When no history exists for the model/dataset combination:
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ History - Decision Tree                                       [X]  │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                     │
+│                    No history found                                 │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## API Integration
+
+### Fetch History
+**Endpoint:** `GET /api/history?model=<model>&dataset=<dataset>`
+
+**Response:**
+```json
+{
+  "runs": [
+    {
+      "runId": "1706540123",
+      "name": "my experiment",
+      "accuracy": 0.98,
+      "timestamp": 1706540123,
+      "hasName": true
+    },
+    {
+      "runId": "1706540000",
+      "name": null,
+      "accuracy": 0.965,
+      "timestamp": 1706540000,
+      "hasName": false
+    }
+  ]
+}
+```
+
+## Implementation Details
+
+- **Modal Component**: Uses standard modal pattern with overlay backdrop
+- **Modal Width**: Uses `w-fit` to size to content, with `max-w-lg` as upper bound
+- **Table/Grid**: Use CSS Grid or HTML table for consistent column widths
+- **Name Column**: `white-space: nowrap` to prevent wrapping, no truncation/ellipsis
+- **Time Formatting**: Use relative time library (e.g., date-fns `formatDistanceToNow`)
+- **Optimistic Updates**: Remove row from UI immediately on delete, restore if API fails
+- **Keyboard Support**: ESC closes modal, Enter on focused delete button triggers action
+- **Accessibility**: Focus trap within modal, proper ARIA labels for delete buttons
+
+## Related specs
+- [frontend/Form](Form.md) - ModelSelector component that triggers this modal
+- [frontend/Layout](Layout.md) - Page navigation after run selection

--- a/specs/frontend/Layout.md
+++ b/specs/frontend/Layout.md
@@ -104,6 +104,7 @@ Inline editing for renaming a training run with a custom name.
 - Placeholder: run ID (so user knows which run they're editing)
 - Input pre-filled with current name (underscores shown as spaces) if one exists, empty otherwise
 - Input width expands dynamically based on text length (minimum width based on run ID length)
+- Maximum length: 50 characters
 - Auto-focused when entering edit mode
 
 **Behavior**:


### PR DESCRIPTION
## Summary
- Add history modal with table layout showing run name/ID, accuracy, time, and delete button
- Modal dynamically expands to fit content width (no horizontal scrolling)
- Delete confirmation for named runs, immediate delete for unnamed
- Add maxLength={50} to run name input field
- Fix compare.py to read train accuracy from result.json (with .id filename fallback)
- Fix .id filename parsing when run has a name suffix