### PR TITLE
feat: add copy/paste buttons for dataset column selection

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -23,6 +23,13 @@ import type { TrainResult } from "@/types/api";
 import type { DatasetId } from "@/types/dataset";
 import type { ModelId } from "@/types/model";
 import type { ModelParams as ModelParamsType } from "@/types/params";
+import type { DatasetId as DatasetIdType } from "@/types/dataset";
+
+// Clipboard state for copying column selection between models
+interface ColumnClipboard {
+  dataset: DatasetIdType;
+  ignore_columns: number[];
+}
 
 interface RuntimeJson {
   run_id: string;
@@ -114,6 +121,9 @@ function HomeContent() {
     historyGradient,
     isLoadingHistory,
   } = useCompare({ dataset, isCompareMode, isModelsTabActive });
+
+  // Column selection clipboard (memory only, not persisted)
+  const [columnClipboard, setColumnClipboard] = useState<ColumnClipboard | null>(null);
 
   const [isLoadingRun, setIsLoadingRun] = useState(false);
   const [isLoadingLatest, setIsLoadingLatest] = useState(false);
@@ -578,6 +588,9 @@ function HomeContent() {
                       dataset={dataset}
                       onChange={setCompareDatasetParams}
                       onReset={resetCompareDatasetParams}
+                      clipboard={columnClipboard}
+                      onCopy={(clipboard) => setColumnClipboard(clipboard)}
+                      onPaste={(ignore_columns) => setCompareDatasetParams({ ignore_columns })}
                     />
                   )}
                   {compareTab === "models" && (
@@ -606,6 +619,9 @@ function HomeContent() {
                       dataset={dataset}
                       onChange={setDatasetParams}
                       onReset={resetDatasetParams}
+                      clipboard={columnClipboard}
+                      onCopy={(clipboard) => setColumnClipboard(clipboard)}
+                      onPaste={(ignore_columns) => setDatasetParams({ ignore_columns })}
                     />
                   )}
                   {trainTab === "model" && (

--- a/frontend/src/components/CompareDatasetParams.tsx
+++ b/frontend/src/components/CompareDatasetParams.tsx
@@ -5,16 +5,42 @@ import type { CompareDatasetParams as CompareDatasetParamsType } from '@/hooks/u
 import type { DatasetId } from '@/types/dataset';
 import { DATASETS } from '@/types/dataset';
 
+interface ColumnClipboard {
+  dataset: DatasetId;
+  ignore_columns: number[];
+}
+
 interface CompareDatasetParamsProps {
   params: CompareDatasetParamsType;
   dataset: DatasetId;
   onChange: (params: Partial<CompareDatasetParamsType>) => void;
   onReset: () => void;
   disabled?: boolean;
+  clipboard?: ColumnClipboard | null;
+  onCopy?: (clipboard: ColumnClipboard) => void;
+  onPaste?: (ignore_columns: number[]) => void;
 }
 
-export function CompareDatasetParams({ params, dataset, onChange, onReset, disabled }: CompareDatasetParamsProps) {
+export function CompareDatasetParams({ params, dataset, onChange, onReset, disabled, clipboard, onCopy, onPaste }: CompareDatasetParamsProps) {
   const columns = DATASETS[dataset].features;
+
+  // Check if paste is available (clipboard has selection for same dataset)
+  const canPaste = clipboard != null && clipboard.dataset === dataset;
+
+  const handleCopy = () => {
+    if (onCopy) {
+      onCopy({
+        dataset,
+        ignore_columns: params.ignore_columns || [],
+      });
+    }
+  };
+
+  const handlePaste = () => {
+    if (onPaste && clipboard && clipboard.dataset === dataset) {
+      onPaste(clipboard.ignore_columns);
+    }
+  };
 
   const handleColumnToggle = (index: number) => {
     const ignore_columns = params.ignore_columns || [];
@@ -71,12 +97,42 @@ export function CompareDatasetParams({ params, dataset, onChange, onReset, disab
             <label className="text-sm font-medium text-gray-700">
               Feature Columns
             </label>
-            <Checkbox
-              label="Select All"
-              checked={allSelected}
-              onChange={handleSelectAll}
-              disabled={disabled}
-            />
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={handleCopy}
+                disabled={disabled}
+                className="flex items-center gap-1 text-xs"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                </svg>
+                Copy
+              </Button>
+              {canPaste && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={handlePaste}
+                  disabled={disabled}
+                  className="flex items-center gap-1 text-xs"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+                </svg>
+                  Paste
+                </Button>
+              )}
+              <Checkbox
+                label="Select All"
+                checked={allSelected}
+                onChange={handleSelectAll}
+                disabled={disabled}
+              />
+            </div>
           </div>
           <div className="flex flex-wrap gap-2">
             {columns.map((col, index) => (

--- a/frontend/src/components/DatasetParams.tsx
+++ b/frontend/src/components/DatasetParams.tsx
@@ -5,16 +5,42 @@ import type { DatasetParams as DatasetParamsType } from '@/types/params';
 import type { DatasetId } from '@/types/dataset';
 import { DATASETS } from '@/types/dataset';
 
+interface ColumnClipboard {
+  dataset: DatasetId;
+  ignore_columns: number[];
+}
+
 interface DatasetParamsProps {
   params: DatasetParamsType;
   dataset: DatasetId;
   onChange: (params: Partial<DatasetParamsType>) => void;
   onReset: () => void;
   disabled?: boolean;
+  clipboard?: ColumnClipboard | null;
+  onCopy?: (clipboard: ColumnClipboard) => void;
+  onPaste?: (ignore_columns: number[]) => void;
 }
 
-export function DatasetParams({ params, dataset, onChange, onReset, disabled }: DatasetParamsProps) {
+export function DatasetParams({ params, dataset, onChange, onReset, disabled, clipboard, onCopy, onPaste }: DatasetParamsProps) {
   const columns = DATASETS[dataset].features;
+
+  // Check if paste is available (clipboard has selection for same dataset)
+  const canPaste = clipboard != null && clipboard.dataset === dataset;
+
+  const handleCopy = () => {
+    if (onCopy) {
+      onCopy({
+        dataset,
+        ignore_columns: params.ignore_columns || [],
+      });
+    }
+  };
+
+  const handlePaste = () => {
+    if (onPaste && clipboard && clipboard.dataset === dataset) {
+      onPaste(clipboard.ignore_columns);
+    }
+  };
 
   const handleColumnToggle = (index: number) => {
     const ignore_columns = params.ignore_columns || [];
@@ -82,12 +108,42 @@ export function DatasetParams({ params, dataset, onChange, onReset, disabled }: 
             <label className="text-sm font-medium text-gray-700">
               Feature Columns
             </label>
-            <Checkbox
-              label="Select All"
-              checked={allSelected}
-              onChange={handleSelectAll}
-              disabled={disabled}
-            />
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={handleCopy}
+                disabled={disabled}
+                className="flex items-center gap-1 text-xs"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                </svg>
+                Copy
+              </Button>
+              {canPaste && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={handlePaste}
+                  disabled={disabled}
+                  className="flex items-center gap-1 text-xs"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+                  </svg>
+                  Paste
+                </Button>
+              )}
+              <Checkbox
+                label="Select All"
+                checked={allSelected}
+                onChange={handleSelectAll}
+                disabled={disabled}
+              />
+            </div>
           </div>
           <div className="flex flex-wrap gap-2">
             {columns.map((col, index) => (

--- a/specs/frontend/Form.md
+++ b/specs/frontend/Form.md
@@ -86,14 +86,17 @@ Columns displayed as a list of checkboxes. User can deselect columns to exclude 
   - Clicking toggles all columns on/off
 
 - **Copy/Paste Selection**: Buttons to copy column selection and paste to other models
-  - **Copy Selection** button: Copies current `ignore_columns` for the current dataset to clipboard state
+  - **Copy** button: Always visible, copies current `ignore_columns` for the current dataset to clipboard state
     - Stored in memory (not localStorage) as `{ dataset: DatasetId, ignore_columns: number[] }`
-    - Button shows copy icon
-  - **Paste Selection** button: Applies copied selection to current model
-    - Only visible when clipboard has selection for the same dataset
-    - Button shows paste icon
-    - Disabled if clipboard dataset doesn't match current dataset
+    - Button shows copy icon with "Copy" text
+    - Copies selection tagged with current dataset type (Iris or Income)
+  - **Paste** button: Applies copied selection to current model
+    - Only visible when clipboard contains selection for the **same dataset type**
+    - If clipboard is empty or contains selection for a different dataset, button is hidden
+    - Button shows paste icon with "Paste" text
+    - Pasting does NOT clear the clipboard - selection can be pasted multiple times
   - Use case: Configure columns for one model, copy, switch to another model, paste to use same columns
+  - Note: Clipboard is cleared only on page refresh, not when pasting
 
 **Iris Dataset:**
 - SepalLengthCm (index 0)
@@ -124,10 +127,13 @@ Columns displayed as a list of checkboxes. User can deselect columns to exclude 
 
 ### Clipboard State
 - `columnClipboard: { dataset: DatasetId, ignore_columns: number[] } | null`
-- Stored in React state (memory only, not persisted)
-- Set when user clicks "Copy Selection"
-- Cleared on page refresh
-- Used to determine if "Paste Selection" button should be visible
+- Stored in React state (memory only, not persisted to localStorage)
+- Set when user clicks "Copy" button
+- **NOT cleared when pasting** - allows multiple paste operations with same selection
+- Cleared only on page refresh
+- Used to determine if "Paste" button should be visible:
+  - Visible only when `columnClipboard !== null` AND `columnClipboard.dataset === currentDataset`
+  - Hidden when clipboard is empty or dataset doesn't match
 
 ## Implementation Details
 - **UI Components**: Button, Select, Input, Checkbox, Slider, Card, Tabs from `components/ui`


### PR DESCRIPTION
## Summary
- Add Copy/Paste buttons for dataset column selection in Train and Compare modes
- Clipboard stores selection tagged with dataset type (Iris/Income)
- Paste button only visible when clipboard contains selection for the same dataset
- Pasting does not clear the clipboard (allows multiple paste operations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)