### PR TITLE
feat: add compare_id and visuals support for compare mode

### DIFF
--- a/frontend/src/app/api/images/route.ts
+++ b/frontend/src/app/api/images/route.ts
@@ -13,22 +13,31 @@ export async function GET(
 ): Promise<NextResponse<ImagesResponse>> {
   const searchParams = request.nextUrl.searchParams;
   const runId = searchParams.get("runId");
+  const compareId = searchParams.get("compareId");
 
-  if (!runId) {
+  // Determine the directory and URL prefix based on parameter
+  let targetDir: string;
+  let urlPrefix: string;
+
+  if (compareId) {
+    targetDir = path.join(OUTPUT_DIR, "compare", compareId);
+    urlPrefix = `/output/compare/${compareId}`;
+  } else if (runId) {
+    targetDir = path.join(OUTPUT_DIR, runId);
+    urlPrefix = `/output/${runId}`;
+  } else {
     return NextResponse.json({ images: [] });
   }
 
   try {
-    const runDir = path.join(OUTPUT_DIR, runId);
-
-    if (!fs.existsSync(runDir)) {
+    if (!fs.existsSync(targetDir)) {
       return NextResponse.json({ images: [] });
     }
 
-    const files = fs.readdirSync(runDir);
+    const files = fs.readdirSync(targetDir);
     const images = files
       .filter((file) => file.endsWith(".png"))
-      .map((file) => `/output/${runId}/${file}`);
+      .map((file) => `${urlPrefix}/${file}`);
 
     return NextResponse.json({ images });
   } catch {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -647,7 +647,10 @@ function HomeContent() {
 
             {/* Compare results */}
             {isCompareMode && compareResult && (
-              <CompareResults result={compareResult} />
+              <div className="grid grid-cols-2 xl:grid-cols-2 gap-6">
+                <CompareResults result={compareResult} />
+                {compareResult.compareId && <ImagesDisplay compareId={compareResult.compareId} />}
+              </div>
             )}
 
             {/* Training results */}

--- a/frontend/src/components/Compare.tsx
+++ b/frontend/src/components/Compare.tsx
@@ -173,6 +173,38 @@ function getBorderColor(ratio: number): string {
   return 'border-red-300';
 }
 
+function ModelAccuracyCard({
+  label,
+  model
+}: {
+  label: string;
+  model: { trainAccuracy: number; compareAccuracy: number; runId: string }
+}) {
+  const ratio = model.compareAccuracy / model.trainAccuracy;
+  return (
+    <div className={`p-3 rounded-lg border ${getBoxBackground(ratio)} ${getBorderColor(ratio)}`}>
+      <p className="text-xs text-gray-500 text-center mb-2">{label}</p>
+      <div className="space-y-1 text-sm">
+        <div className="flex justify-between">
+          <span className="text-gray-500">Train:</span>
+          <span className="font-medium">{(model.trainAccuracy * 100).toFixed(2)}%</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-gray-500">Compare:</span>
+          <span className="font-bold">{(model.compareAccuracy * 100).toFixed(2)}%</span>
+        </div>
+        <div className={`flex justify-between border-t pt-1 mt-1 ${getBorderColor(ratio)}`}>
+          <span className="text-gray-500">Diff:</span>
+          <span className={`font-medium ${getRatioColor(ratio)}`}>
+            {getRatioIcon(ratio)} {formatRatio(ratio)}
+          </span>
+        </div>
+      </div>
+      <p className="text-xs text-gray-400 font-mono text-center mt-2">{model.runId}</p>
+    </div>
+  );
+}
+
 export function CompareResults({ result }: CompareResultsProps) {
   return (
     <Card variant="elevated">
@@ -180,105 +212,15 @@ export function CompareResults({ result }: CompareResultsProps) {
         <CardTitle>Comparison Results</CardTitle>
       </CardHeader>
 
-      <div className="space-y-6">
-        {/* Model accuracy summary */}
-        <div>
-          <h4 className="text-sm font-medium text-gray-700 mb-3">Model Accuracies</h4>
-          <div className="grid grid-cols-3 gap-4">
-            {result.models.tree && (() => {
-              const ratio = result.models.tree.compareAccuracy / result.models.tree.trainAccuracy;
-              return (
-                <div className={`p-3 rounded-lg border ${getBoxBackground(ratio)} ${getBorderColor(ratio)}`}>
-                  <p className="text-xs text-gray-500 text-center mb-2">Decision Tree</p>
-                  <div className="space-y-1 text-sm">
-                    <div className="flex justify-between">
-                      <span className="text-gray-500">Train:</span>
-                      <span className="font-medium">{(result.models.tree.trainAccuracy * 100).toFixed(2)}%</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-gray-500">Compare:</span>
-                      <span className="font-bold">{(result.models.tree.compareAccuracy * 100).toFixed(2)}%</span>
-                    </div>
-                    <div className={`flex justify-between border-t pt-1 mt-1 ${getBorderColor(ratio)}`}>
-                      <span className="text-gray-500">Diff:</span>
-                      <span className={`font-medium ${getRatioColor(ratio)}`}>
-                        {getRatioIcon(ratio)} {formatRatio(ratio)}
-                      </span>
-                    </div>
-                  </div>
-                  <p className="text-xs text-gray-400 font-mono text-center mt-2">{result.models.tree.runId}</p>
-                </div>
-              );
-            })()}
-            {result.models.forest && (() => {
-              const ratio = result.models.forest.compareAccuracy / result.models.forest.trainAccuracy;
-              return (
-                <div className={`p-3 rounded-lg border ${getBoxBackground(ratio)} ${getBorderColor(ratio)}`}>
-                  <p className="text-xs text-gray-500 text-center mb-2">Random Forest</p>
-                  <div className="space-y-1 text-sm">
-                    <div className="flex justify-between">
-                      <span className="text-gray-500">Train:</span>
-                      <span className="font-medium">{(result.models.forest.trainAccuracy * 100).toFixed(2)}%</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-gray-500">Compare:</span>
-                      <span className="font-bold">{(result.models.forest.compareAccuracy * 100).toFixed(2)}%</span>
-                    </div>
-                    <div className={`flex justify-between border-t pt-1 mt-1 ${getBorderColor(ratio)}`}>
-                      <span className="text-gray-500">Diff:</span>
-                      <span className={`font-medium ${getRatioColor(ratio)}`}>
-                        {getRatioIcon(ratio)} {formatRatio(ratio)}
-                      </span>
-                    </div>
-                  </div>
-                  <p className="text-xs text-gray-400 font-mono text-center mt-2">{result.models.forest.runId}</p>
-                </div>
-              );
-            })()}
-            {result.models.gradient && (() => {
-              const ratio = result.models.gradient.compareAccuracy / result.models.gradient.trainAccuracy;
-              return (
-                <div className={`p-3 rounded-lg border ${getBoxBackground(ratio)} ${getBorderColor(ratio)}`}>
-                  <p className="text-xs text-gray-500 text-center mb-2">Gradient Boosted</p>
-                  <div className="space-y-1 text-sm">
-                    <div className="flex justify-between">
-                      <span className="text-gray-500">Train:</span>
-                      <span className="font-medium">{(result.models.gradient.trainAccuracy * 100).toFixed(2)}%</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-gray-500">Compare:</span>
-                      <span className="font-bold">{(result.models.gradient.compareAccuracy * 100).toFixed(2)}%</span>
-                    </div>
-                    <div className={`flex justify-between border-t pt-1 mt-1 ${getBorderColor(ratio)}`}>
-                      <span className="text-gray-500">Diff:</span>
-                      <span className={`font-medium ${getRatioColor(ratio)}`}>
-                        {getRatioIcon(ratio)} {formatRatio(ratio)}
-                      </span>
-                    </div>
-                  </div>
-                  <p className="text-xs text-gray-400 font-mono text-center mt-2">{result.models.gradient.runId}</p>
-                </div>
-              );
-            })()}
-          </div>
-        </div>
-
-        {/* Comparison images */}
-        {result.images.length > 0 && (
-          <div>
-            <h4 className="text-sm font-medium text-gray-700 mb-3">Comparison Charts</h4>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              {result.images.map((src, i) => (
-                <div key={i} className="border border-gray-200 rounded-lg overflow-hidden">
-                  <img
-                    src={src}
-                    alt={`Comparison chart ${i + 1}`}
-                    className="w-full h-auto"
-                  />
-                </div>
-              ))}
-            </div>
-          </div>
+      <div className="space-y-4">
+        {result.models.tree && (
+          <ModelAccuracyCard label="Decision Tree" model={result.models.tree} />
+        )}
+        {result.models.forest && (
+          <ModelAccuracyCard label="Random Forest" model={result.models.forest} />
+        )}
+        {result.models.gradient && (
+          <ModelAccuracyCard label="Gradient Boosted" model={result.models.gradient} />
         )}
       </div>
     </Card>

--- a/frontend/src/components/ImageGallery.tsx
+++ b/frontend/src/components/ImageGallery.tsx
@@ -1,0 +1,292 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+
+function Spinner() {
+  return (
+    <svg
+      className="animate-spin h-5 w-5 text-blue-600"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+      />
+    </svg>
+  );
+}
+
+export function beautifyImageName(src: string): string {
+  // Extract filename from path
+  const filename = src.split('/').pop() || '';
+  // Remove extension
+  const nameWithoutExt = filename.replace(/\.[^/.]+$/, '');
+  // Replace dashes and underscores with spaces
+  const withSpaces = nameWithoutExt.replace(/[-_]/g, ' ');
+  // Capitalize each word (Title Case)
+  return withSpaces
+    .split(' ')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
+}
+
+interface ZoomableImageModalProps {
+  src: string | null;
+  onClose: () => void;
+}
+
+export function ZoomableImageModal({ src, onClose }: ZoomableImageModalProps) {
+  const [zoom, setZoom] = useState(1);
+  const [imageSize, setImageSize] = useState<{ width: number; height: number } | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const imageRef = useRef<HTMLImageElement>(null);
+
+  useEffect(() => {
+    if (src) {
+      setZoom(1);
+      setImageSize(null);
+    }
+  }, [src]);
+
+  const zoomToPoint = (newZoom: number, clientX: number, clientY: number) => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const rect = container.getBoundingClientRect();
+    const mouseX = clientX - rect.left + container.scrollLeft;
+    const mouseY = clientY - rect.top + container.scrollTop;
+
+    const oldZoom = zoom;
+    const clampedZoom = Math.max(0.1, Math.min(5, newZoom));
+
+    // Calculate new scroll position to keep point under cursor
+    const scale = clampedZoom / oldZoom;
+    const newScrollLeft = mouseX * scale - (clientX - rect.left);
+    const newScrollTop = mouseY * scale - (clientY - rect.top);
+
+    setZoom(clampedZoom);
+
+    requestAnimationFrame(() => {
+      container.scrollLeft = newScrollLeft;
+      container.scrollTop = newScrollTop;
+    });
+  };
+
+  useEffect(() => {
+    if (!src) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      } else if (e.key === '+' || e.key === '=') {
+        setZoom((z) => Math.min(5, z + 0.1));
+      } else if (e.key === '-') {
+        setZoom((z) => Math.max(0.1, z - 0.1));
+      } else if (e.key === '0') {
+        setZoom(1);
+      }
+    };
+
+    const container = containerRef.current;
+    const handleWheel = (e: WheelEvent) => {
+      if (e.ctrlKey || e.metaKey) {
+        e.preventDefault();
+        const delta = e.deltaY > 0 ? -0.02 : 0.02;
+        zoomToPoint(zoom + delta, e.clientX, e.clientY);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    container?.addEventListener('wheel', handleWheel, { passive: false });
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      container?.removeEventListener('wheel', handleWheel);
+      document.body.style.overflow = '';
+    };
+  }, [src, onClose, zoom]);
+
+  const handleImageLoad = () => {
+    if (imageRef.current) {
+      setImageSize({
+        width: imageRef.current.naturalWidth,
+        height: imageRef.current.naturalHeight,
+      });
+    }
+  };
+
+  if (!src) return null;
+
+  const scaledWidth = imageSize ? imageSize.width * zoom : undefined;
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col bg-black/90">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 bg-black/50 text-white">
+        <span className="text-sm font-medium truncate">{src.split('/').pop()}</span>
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-gray-300">{Math.round(zoom * 100)}%</span>
+          <button
+            onClick={() => setZoom((z) => Math.max(0.1, z - 0.1))}
+            className="p-1.5 rounded hover:bg-white/20"
+            title="Zoom out (-)"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
+            </svg>
+          </button>
+          <button
+            onClick={() => setZoom(1)}
+            className="px-2 py-1 text-xs rounded hover:bg-white/20"
+            title="Reset zoom (0)"
+          >
+            Reset
+          </button>
+          <button
+            onClick={() => setZoom((z) => Math.min(5, z + 0.1))}
+            className="p-1.5 rounded hover:bg-white/20"
+            title="Zoom in (+)"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            </svg>
+          </button>
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded hover:bg-white/20 ml-2"
+            title="Close (Esc)"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* Scrollable image container */}
+      <div
+        ref={containerRef}
+        className="flex-1 overflow-auto"
+      >
+        <div
+          className="flex items-center justify-center p-4"
+          style={{
+            minWidth: '100%',
+            minHeight: '100%',
+            width: scaledWidth && scaledWidth > window.innerWidth - 32 ? `${scaledWidth + 32}px` : '100%',
+            height: imageSize && imageSize.height * zoom > window.innerHeight - 150 ? `${imageSize.height * zoom + 32}px` : '100%',
+          }}
+        >
+          <img
+            ref={imageRef}
+            src={src}
+            alt={src.split('/').pop() || 'Generated image'}
+            onLoad={handleImageLoad}
+            style={{
+              width: scaledWidth ? `${scaledWidth}px` : 'auto',
+            }}
+            className="block"
+            draggable={false}
+          />
+        </div>
+      </div>
+
+      {/* Footer hint */}
+      <div className="px-4 py-2 bg-black/50 text-center text-xs text-gray-400">
+        Scroll to pan | Ctrl+Scroll to zoom at pointer | +/- keys to zoom | 0 to reset
+      </div>
+    </div>
+  );
+}
+
+interface ImageGalleryProps {
+  runId?: string;
+  compareId?: string;
+}
+
+export function ImageGallery({ runId, compareId }: ImageGalleryProps) {
+  const [images, setImages] = useState<string[]>([]);
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchImages() {
+      setIsLoading(true);
+      try {
+        let url: string;
+        if (compareId) {
+          url = `/api/images?compareId=${compareId}`;
+        } else if (runId) {
+          url = `/api/images?runId=${runId}`;
+        } else {
+          setImages([]);
+          setIsLoading(false);
+          return;
+        }
+        const res = await fetch(url);
+        const data = await res.json();
+        setImages(data.images || []);
+      } catch {
+        setImages([]);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    fetchImages();
+  }, [runId, compareId]);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-4">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (images.length === 0) {
+    return null;
+  }
+
+  return (
+    <div>
+      <h4 className="text-sm font-medium text-gray-700 mb-3">Visuals</h4>
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+        {images.map((src) => (
+          <button
+            key={src}
+            onClick={() => setSelectedImage(src)}
+            className="flex flex-col rounded-lg overflow-hidden border border-gray-200 hover:border-gray-400 transition-colors bg-white"
+          >
+            <div className="aspect-square overflow-hidden">
+              <img
+                src={src}
+                alt={beautifyImageName(src)}
+                className="w-full h-full object-contain"
+              />
+            </div>
+            <span className="text-xs text-gray-600 px-2 py-1.5 text-center">
+              {beautifyImageName(src)}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      <ZoomableImageModal
+        src={selectedImage}
+        onClose={() => setSelectedImage(null)}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/ResultsDisplay.tsx
+++ b/frontend/src/components/ResultsDisplay.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState, useMemo, useEffect, useRef } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { Card, CardHeader, CardTitle, Badge, Tabs, Modal } from './ui';
+import { ImageGallery } from './ImageGallery';
 import type { TrainResult } from '@/types/api';
 
 interface ResultsDisplayProps {
@@ -194,20 +195,6 @@ function formatCellValue(value: unknown): string {
   return String(value);
 }
 
-function beautifyImageName(src: string): string {
-  // Extract filename from path
-  const filename = src.split('/').pop() || '';
-  // Remove extension
-  const nameWithoutExt = filename.replace(/\.[^/.]+$/, '');
-  // Replace dashes and underscores with spaces
-  const withSpaces = nameWithoutExt.replace(/[-_]/g, ' ');
-  // Capitalize each word (Title Case)
-  return withSpaces
-    .split(' ')
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-    .join(' ');
-}
-
 function ExpandIcon() {
   return (
     <svg
@@ -223,245 +210,6 @@ function ExpandIcon() {
         d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"
       />
     </svg>
-  );
-}
-
-interface ImageGalleryProps {
-  runId: string;
-}
-
-interface ZoomableImageModalProps {
-  src: string | null;
-  onClose: () => void;
-}
-
-function ZoomableImageModal({ src, onClose }: ZoomableImageModalProps) {
-  const [zoom, setZoom] = useState(1);
-  const [imageSize, setImageSize] = useState<{ width: number; height: number } | null>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const imageRef = useRef<HTMLImageElement>(null);
-
-  useEffect(() => {
-    if (src) {
-      setZoom(1);
-      setImageSize(null);
-    }
-  }, [src]);
-
-  const zoomToPoint = (newZoom: number, clientX: number, clientY: number) => {
-    const container = containerRef.current;
-    if (!container) return;
-
-    const rect = container.getBoundingClientRect();
-    const mouseX = clientX - rect.left + container.scrollLeft;
-    const mouseY = clientY - rect.top + container.scrollTop;
-
-    const oldZoom = zoom;
-    const clampedZoom = Math.max(0.1, Math.min(5, newZoom));
-
-    // Calculate new scroll position to keep point under cursor
-    const scale = clampedZoom / oldZoom;
-    const newScrollLeft = mouseX * scale - (clientX - rect.left);
-    const newScrollTop = mouseY * scale - (clientY - rect.top);
-
-    setZoom(clampedZoom);
-
-    requestAnimationFrame(() => {
-      container.scrollLeft = newScrollLeft;
-      container.scrollTop = newScrollTop;
-    });
-  };
-
-  useEffect(() => {
-    if (!src) return;
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose();
-      } else if (e.key === '+' || e.key === '=') {
-        setZoom((z) => Math.min(5, z + 0.1));
-      } else if (e.key === '-') {
-        setZoom((z) => Math.max(0.1, z - 0.1));
-      } else if (e.key === '0') {
-        setZoom(1);
-      }
-    };
-
-    const container = containerRef.current;
-    const handleWheel = (e: WheelEvent) => {
-      if (e.ctrlKey || e.metaKey) {
-        e.preventDefault();
-        const delta = e.deltaY > 0 ? -0.02 : 0.02;
-        zoomToPoint(zoom + delta, e.clientX, e.clientY);
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    container?.addEventListener('wheel', handleWheel, { passive: false });
-    document.body.style.overflow = 'hidden';
-
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-      container?.removeEventListener('wheel', handleWheel);
-      document.body.style.overflow = '';
-    };
-  }, [src, onClose, zoom]);
-
-  const handleImageLoad = () => {
-    if (imageRef.current) {
-      setImageSize({
-        width: imageRef.current.naturalWidth,
-        height: imageRef.current.naturalHeight,
-      });
-    }
-  };
-
-  if (!src) return null;
-
-  const scaledWidth = imageSize ? imageSize.width * zoom : undefined;
-
-  return (
-    <div className="fixed inset-0 z-50 flex flex-col bg-black/90">
-      {/* Header */}
-      <div className="flex items-center justify-between px-4 py-3 bg-black/50 text-white">
-        <span className="text-sm font-medium truncate">{src.split('/').pop()}</span>
-        <div className="flex items-center gap-2">
-          <span className="text-sm text-gray-300">{Math.round(zoom * 100)}%</span>
-          <button
-            onClick={() => setZoom((z) => Math.max(0.1, z - 0.1))}
-            className="p-1.5 rounded hover:bg-white/20"
-            title="Zoom out (-)"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
-            </svg>
-          </button>
-          <button
-            onClick={() => setZoom(1)}
-            className="px-2 py-1 text-xs rounded hover:bg-white/20"
-            title="Reset zoom (0)"
-          >
-            Reset
-          </button>
-          <button
-            onClick={() => setZoom((z) => Math.min(5, z + 0.1))}
-            className="p-1.5 rounded hover:bg-white/20"
-            title="Zoom in (+)"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-            </svg>
-          </button>
-          <button
-            onClick={onClose}
-            className="p-1.5 rounded hover:bg-white/20 ml-2"
-            title="Close (Esc)"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
-      </div>
-
-      {/* Scrollable image container */}
-      <div
-        ref={containerRef}
-        className="flex-1 overflow-auto"
-      >
-        <div
-          className="flex items-center justify-center p-4"
-          style={{
-            minWidth: '100%',
-            minHeight: '100%',
-            width: scaledWidth && scaledWidth > window.innerWidth - 32 ? `${scaledWidth + 32}px` : '100%',
-            height: imageSize && imageSize.height * zoom > window.innerHeight - 150 ? `${imageSize.height * zoom + 32}px` : '100%',
-          }}
-        >
-          <img
-            ref={imageRef}
-            src={src}
-            alt={src.split('/').pop() || 'Generated image'}
-            onLoad={handleImageLoad}
-            style={{
-              width: scaledWidth ? `${scaledWidth}px` : 'auto',
-            }}
-            className="block"
-            draggable={false}
-          />
-        </div>
-      </div>
-
-      {/* Footer hint */}
-      <div className="px-4 py-2 bg-black/50 text-center text-xs text-gray-400">
-        Scroll to pan | Ctrl+Scroll to zoom at pointer | +/- keys to zoom | 0 to reset
-      </div>
-    </div>
-  );
-}
-
-function ImageGallery({ runId }: ImageGalleryProps) {
-  const [images, setImages] = useState<string[]>([]);
-  const [selectedImage, setSelectedImage] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    async function fetchImages() {
-      setIsLoading(true);
-      try {
-        const res = await fetch(`/api/images?runId=${runId}`);
-        const data = await res.json();
-        setImages(data.images || []);
-      } catch {
-        setImages([]);
-      } finally {
-        setIsLoading(false);
-      }
-    }
-    fetchImages();
-  }, [runId]);
-
-  if (isLoading) {
-    return (
-      <div className="flex justify-center py-4">
-        <Spinner />
-      </div>
-    );
-  }
-
-  if (images.length === 0) {
-    return null;
-  }
-
-  return (
-    <div>
-      <h4 className="text-sm font-medium text-gray-700 mb-3">Visuals</h4>
-      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
-        {images.map((src) => (
-          <button
-            key={src}
-            onClick={() => setSelectedImage(src)}
-            className="flex flex-col rounded-lg overflow-hidden border border-gray-200 hover:border-gray-400 transition-colors bg-white"
-          >
-            <div className="aspect-square overflow-hidden">
-              <img
-                src={src}
-                alt={beautifyImageName(src)}
-                className="w-full h-full object-contain"
-              />
-            </div>
-            <span className="text-xs text-gray-600 px-2 py-1.5 text-center">
-              {beautifyImageName(src)}
-            </span>
-          </button>
-        ))}
-      </div>
-
-      <ZoomableImageModal
-        src={selectedImage}
-        onClose={() => setSelectedImage(null)}
-      />
-    </div>
   );
 }
 
@@ -711,77 +459,17 @@ export function ResultsDisplay({ result, isLoading }: ResultsDisplayProps) {
 }
 
 interface ImagesDisplayProps {
-  runId: string;
+  runId?: string;
+  compareId?: string;
 }
 
-export function ImagesDisplay({ runId }: ImagesDisplayProps) {
-  const [images, setImages] = useState<string[]>([]);
-  const [selectedImage, setSelectedImage] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    async function fetchImages() {
-      setIsLoading(true);
-      try {
-        const res = await fetch(`/api/images?runId=${runId}`);
-        const data = await res.json();
-        setImages(data.images || []);
-      } catch {
-        setImages([]);
-      } finally {
-        setIsLoading(false);
-      }
-    }
-    fetchImages();
-  }, [runId]);
-
-  if (isLoading) {
-    return (
-      <Card variant="elevated">
-        <CardHeader>
-          <CardTitle>Visuals</CardTitle>
-        </CardHeader>
-        <div className="flex justify-center py-8">
-          <Spinner />
-        </div>
-      </Card>
-    );
-  }
-
-  if (images.length === 0) {
-    return null;
-  }
-
+export function ImagesDisplay({ runId, compareId }: ImagesDisplayProps) {
   return (
     <Card variant="elevated">
       <CardHeader>
         <CardTitle>Visuals</CardTitle>
       </CardHeader>
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-        {images.map((src) => (
-          <button
-            key={src}
-            onClick={() => setSelectedImage(src)}
-            className="flex flex-col rounded-lg overflow-hidden border border-gray-200 hover:border-gray-400 transition-colors bg-white"
-          >
-            <div className="aspect-square overflow-hidden">
-              <img
-                src={src}
-                alt={beautifyImageName(src)}
-                className="w-full h-full object-contain"
-              />
-            </div>
-            <span className="text-xs text-gray-600 px-2 py-1.5 text-center">
-              {beautifyImageName(src)}
-            </span>
-          </button>
-        ))}
-      </div>
-
-      <ZoomableImageModal
-        src={selectedImage}
-        onClose={() => setSelectedImage(null)}
-      />
+      <ImageGallery runId={runId} compareId={compareId} />
     </Card>
   );
 }

--- a/frontend/src/hooks/useCompare.ts
+++ b/frontend/src/hooks/useCompare.ts
@@ -32,6 +32,7 @@ export interface CompareModelResult {
 }
 
 export interface CompareResult {
+  compareId: string;
   images: string[];
   models: {
     tree: CompareModelResult | null;

--- a/specs/frontend/Output.md
+++ b/specs/frontend/Output.md
@@ -1,7 +1,7 @@
 # Frontend Output
 
 ## Overview
-Components for displaying training results, datasets, and errors.
+Components for displaying training results, datasets, errors, and shared visual components used across train and compare modes.
 
 ## Requirements
 - Results displayed in tabbed interface (Results tab, Dataset tab)
@@ -9,6 +9,7 @@ Components for displaying training results, datasets, and errors.
 - Dataset tab: sortable table showing train/test data with filtered fields
 - Error card with dismissible display, error details, and optional stack trace
 - Accuracy badge color-coded by performance (green ≥90%, yellow ≥70%, red <70%)
+- Shared visual components extracted for reuse across Train and Compare modes
 
 ## Components
 
@@ -38,24 +39,7 @@ Components for displaying training results, datasets, and errors.
   - Bar opacity/intensity determined by importance value (e.g., 0.90 importance = 0.9 alpha)
   - Feature name on left, importance value on right
   - Bars sorted by importance descending
-- **Visuals section**: Grid of PNG images from the run
-  - Fetches list of `.png` files from `/output/<runId>/`
-  - Displays as thumbnail grid (responsive: 2 cols mobile, 3 cols tablet, 4 cols desktop)
-  - Each image has a beautified label below it (full name, not truncated):
-    - Remove file extension (`.png`)
-    - Replace dashes (`-`) and underscores (`_`) with spaces
-    - Capitalize each word (Title Case)
-    - Example: `feature_importance-chart.png` → "Feature Importance Chart"
-  - Clicking image opens fullscreen zoomable modal
-  - **Zoomable Image Modal**:
-    - Dark overlay with image centered
-    - Zoom controls in header: zoom out (-), reset, zoom in (+), close (X)
-    - Shows current zoom percentage
-    - Keyboard shortcuts: +/- to zoom, 0 to reset, Esc to close
-    - Ctrl+Scroll to zoom in/out
-    - Scroll to pan when zoomed in
-    - Footer shows keyboard hints
-    - Zoom range: 10% to 500%, step 10%
+- **Visuals section**: Uses shared `ImageGallery` component (see Shared Visual Components below)
 - Execution time footer
 
 #### Dataset Tab
@@ -130,6 +114,51 @@ Components for displaying training results, datasets, and errors.
 }
 ```
 
+## Shared Visual Components
+
+Components extracted for reuse across Train results and Compare results.
+
+### ImageGallery
+- Fetches and displays PNG images in a responsive grid
+- **Props:**
+  - `runId?: string` - Training run ID (fetches from `/api/images?runId=...`)
+  - `compareId?: string` - Compare run ID (fetches from `/api/images?compareId=...`)
+  - One of `runId` or `compareId` must be provided
+- Displays loading spinner while fetching
+- Returns null if no images found
+- Grid layout: 2 cols mobile, 3 cols tablet, 4 cols desktop
+- Each image has a beautified label below it (full name, not truncated):
+  - Remove file extension (`.png`)
+  - Replace dashes (`-`) and underscores (`_`) with spaces
+  - Capitalize each word (Title Case)
+  - Example: `feature_importance-chart.png` → "Feature Importance Chart"
+- Clicking image opens `ZoomableImageModal`
+
+### ZoomableImageModal
+- Fullscreen modal for viewing images with zoom/pan capabilities
+- **Props:**
+  - `src: string | null` - Image source URL (null to hide modal)
+  - `onClose: () => void` - Callback to close modal
+- **Features:**
+  - Dark overlay with image centered
+  - Zoom controls in header: zoom out (-), reset, zoom in (+), close (X)
+  - Shows current zoom percentage
+  - Keyboard shortcuts: +/- to zoom, 0 to reset, Esc to close
+  - Ctrl+Scroll to zoom in/out at pointer location
+  - Scroll to pan when zoomed in
+  - Footer shows keyboard hints
+  - Zoom range: 10% to 500%, step 10%
+
+### beautifyImageName (utility)
+- Transforms image filename to human-readable label
+- **Input:** Full image path (e.g., `/output/123/feature_importance-chart.png`)
+- **Output:** Beautified name (e.g., "Feature Importance Chart")
+- **Logic:**
+  1. Extract filename from path
+  2. Remove file extension
+  3. Replace dashes and underscores with spaces
+  4. Capitalize each word (Title Case)
+
 ## Implementation Details
 - **Badge Component**: Uses `variant` prop for color (success/warning/error)
 - **Table**: Responsive with `overflow-x-auto` wrapper
@@ -146,7 +175,11 @@ Components for displaying training results, datasets, and errors.
     - F key opens fullscreen (when Dataset tab active and modal closed)
     - ESC key closes modal
   - Body scroll locked when modal is open
+- **Shared components location**: `frontend/src/components/ImageGallery.tsx`
+  - Export `ImageGallery`, `ZoomableImageModal`, and `beautifyImageName`
+  - Import into `ResultsDisplay.tsx` and `Compare.tsx`
 
 ## Related specs
 - [frontend/Layout](Layout.md) - Page structure
 - [frontend/Form](Form.md) - Form inputs
+- [frontend/Compare](Compare.md) - Compare mode (uses shared visual components)

--- a/specs/lib/Render.md
+++ b/specs/lib/Render.md
@@ -14,7 +14,8 @@ Visualization utilities for model analysis. Generates matplotlib plots for featu
 |--------|-------------|
 | `set_mask(mask_rate)` | Set mask percentage for filename prefixes |
 | `set_run_id(run_id)` | Set run ID for output directory (overrides legacy path) |
-| `get_output_path(filename)` | Get full output path based on run_id or legacy mode |
+| `set_compare_id(compare_id)` | Set compare ID for compare output directory |
+| `get_output_path(filename)` | Get full output path based on compare_id, run_id, or legacy mode |
 | `header(figsize, subplots)` | Initialize figure/axes |
 | `footer(filename, title, dpi)` | Save and close figure |
 | `heatmap(X, filename)` | Feature correlation heatmap |
@@ -48,14 +49,18 @@ Visualization utilities for model analysis. Generates matplotlib plots for featu
 |--------|-------------|
 | `compare_accuracy(mask_values, results, colors, filename)` | Accuracy comparison line plot |
 | `compare_accuracy_impute(mask_values, results, colors, filename)` | Accuracy comparison with impute variants |
+| `compare_accuracy_bars(models, filename)` | Bar chart comparing train vs compare accuracy for each model |
+| `compare_accuracy_diff(models, filename)` | Visual representation of accuracy differences (ratio chart) |
 
 ## Implementation Details
 - **Libraries**: matplotlib, seaborn, sklearn.tree.plot_tree, sklearn.inspection (PartialDependenceDisplay, DecisionBoundaryDisplay)
 - **Location**: `lib/dataset/render.py`
 - **Output paths**:
+  - With `compare_id`: `frontend/public/output/compare/{compare_id}/{filename}` (no mask prefix)
   - With `run_id`: `frontend/public/output/{run_id}/{filename}` (no mask prefix)
   - Legacy (no run_id): `./output/{base}_{mask_pct}.{ext}`
-- **Path function**: `get_output_path(filename)` returns the full path based on current run_id or legacy mode
+- **Path priority**: `compare_id` > `run_id` > legacy mode
+- **Path function**: `get_output_path(filename)` returns the full path based on current compare_id, run_id, or legacy mode
 - **Default DPI**: 150
 - **Tree grids**: `forest_trees` uses 5x4 inches per cell, 150 DPI for all grid sizes
 


### PR DESCRIPTION
## Summary
- Add `compare_id` generation (timestamp) when running compare with model IDs
- Add `--compare-id` and `--images` flags to compare.py
- Output comparison images to `frontend/public/output/compare/<compare_id>/`
- Add `compare_accuracy_bars` and `compare_accuracy_diff` visualizations in lib/Render
- Extract shared `ImageGallery` component from ResultsDisplay for reuse
- Update `/api/images` to support `compareId` parameter
- Display compare results in 2-column layout (same as Train view)
- Update specs for compare_id and layout changes