### PR TITLE
feat: support arbitrary models in compare functionality

### DIFF
--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -7,4 +7,4 @@ export { ModelParams } from './ModelParams';
 export { TrainButton } from './TrainButton';
 export { ResultsDisplay, ImagesDisplay } from './ResultsDisplay';
 export { ErrorDisplay } from './ErrorDisplay';
-export { CompareModelsTab, CompareButton, CompareResults, ModelHistorySelect } from './Compare';
+export { CompareModelsList, CompareButton, CompareResults, ModelRow } from './Compare';

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -11,11 +11,20 @@ const selectLabel = tv({
 
 const selectElement = tv({
   base: [
-    'block w-full rounded-lg border border-gray-300 bg-white px-3 py-2',
+    'block w-full rounded-lg border bg-white px-3 py-2',
     'text-gray-900 text-sm',
-    'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500',
+    'focus:outline-none focus:ring-2 focus:border-blue-500',
     'disabled:opacity-50 disabled:cursor-not-allowed',
   ],
+  variants: {
+    error: {
+      true: 'border-red-500 focus:ring-red-500',
+      false: 'border-gray-300 focus:ring-blue-500',
+    },
+  },
+  defaultVariants: {
+    error: false,
+  },
 });
 
 interface SelectOption {
@@ -30,6 +39,7 @@ interface SelectProps {
   onChange: (value: string) => void;
   options: SelectOption[];
   disabled?: boolean;
+  error?: boolean;
   className?: string;
 }
 
@@ -40,6 +50,7 @@ export function Select({
   onChange,
   options,
   disabled,
+  error,
   className,
 }: SelectProps) {
   return (
@@ -54,7 +65,7 @@ export function Select({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         disabled={disabled}
-        className={selectElement()}
+        className={selectElement({ error })}
       >
         {options.map((option) => (
           <option key={option.value} value={option.value}>

--- a/specs/lib/Render.md
+++ b/specs/lib/Render.md
@@ -49,8 +49,18 @@ Visualization utilities for model analysis. Generates matplotlib plots for featu
 |--------|-------------|
 | `compare_accuracy(mask_values, results, colors, filename)` | Accuracy comparison line plot |
 | `compare_accuracy_impute(mask_values, results, colors, filename)` | Accuracy comparison with impute variants |
-| `compare_accuracy_bars(models, filename)` | Bar chart comparing train vs compare accuracy for all 4 models (tree, forest, gradient, hist-gradient) |
-| `compare_accuracy_diff(models, filename)` | Accuracy ratio chart for all 4 models |
+| `compare_accuracy_bars(models, filename)` | Bar chart comparing train vs compare accuracy for all compared models (array format) |
+| `compare_accuracy_diff(models, filename)` | Accuracy ratio chart for all compared models (array format) |
+
+**Note**: `compare_accuracy_bars` and `compare_accuracy_diff` accept an array of model results:
+```python
+[
+  {"model": "tree", "runId": "123", "trainAccuracy": 0.96, "compareAccuracy": 0.92, "imputed": False},
+  {"model": "forest", "runId": "456", "trainAccuracy": 0.98, "compareAccuracy": 0.95, "imputed": False},
+  ...
+]
+```
+The charts dynamically size to show all compared models with their run IDs and imputation status.
 
 ## Implementation Details
 - **Libraries**: matplotlib, seaborn, sklearn.tree.plot_tree, sklearn.inspection (PartialDependenceDisplay, DecisionBoundaryDisplay)


### PR DESCRIPTION
## Summary
- Replace fixed `--tree`/`--forest`/`--gradient`/`--hist-gradient` flags with `--model` flag that accepts any run ID
- Auto-detect model type from runtime config instead of requiring explicit type specification
- Update Render functions (`compare_accuracy_bars`, `compare_accuracy_diff`) to accept array format for dynamic model count
- Update frontend to support multi-model selection with autocomplete input
- Charts dynamically size based on number of compared models, showing run IDs and imputation status