### PR TITLE
feat: add compare history functionality

### DIFF
--- a/compare.py
+++ b/compare.py
@@ -374,6 +374,37 @@ def main():
             Render.compare_accuracy_diff(results, "accuracy_diff.png")
             print(f"  Images saved to frontend/public/output/compare/{compare_id}/", file=sys.stderr)
 
+        # Save results.json and runtime.json for compare history
+        compare_dir = os.path.realpath(os.path.join(
+            os.path.dirname(__file__), 'frontend', 'public', 'output', 'compare', compare_id
+        ))
+        os.makedirs(compare_dir, exist_ok=True)
+
+        # Save results.json with accuracy statistics
+        results_data = {
+            "compareId": compare_id,
+            "mask": args.mask,
+            "impute": args.impute,
+            "dataset": args.dataset,
+            "models": results
+        }
+        with open(os.path.join(compare_dir, 'results.json'), 'w') as f:
+            json.dump(results_data, f, indent=2)
+
+        # Save runtime.json with runtime parameters
+        runtime_data = {
+            "compare_id": compare_id,
+            "dataset": args.dataset,
+            "mask": args.mask,
+            "impute": args.impute,
+            "name": None,
+            "models": [{"runId": run_id, "model": model_type} for run_id, model_type, _ in runtimes]
+        }
+        with open(os.path.join(compare_dir, 'runtime.json'), 'w') as f:
+            json.dump(runtime_data, f, indent=2)
+
+        print(f"  Saved results.json and runtime.json to compare/{compare_id}/", file=sys.stderr)
+
         # Output results as JSON (array format)
         print(json.dumps({
             "success": True,

--- a/frontend/src/app/api/compare/history/[compareId]/route.ts
+++ b/frontend/src/app/api/compare/history/[compareId]/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+
+const OUTPUT_DIR = path.join(process.cwd(), "public", "output");
+const COMPARE_DIR = path.join(OUTPUT_DIR, "compare");
+
+interface DeleteResponse {
+  success: boolean;
+  error?: string;
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ compareId: string }> }
+): Promise<NextResponse<DeleteResponse>> {
+  const { compareId } = await params;
+
+  // Validate compareId is a 10-digit timestamp
+  if (!/^\d{10}$/.test(compareId)) {
+    return NextResponse.json(
+      { success: false, error: "Invalid compare ID format" },
+      { status: 400 }
+    );
+  }
+
+  const compareDir = path.join(COMPARE_DIR, compareId);
+
+  try {
+    // Check if directory exists
+    if (!fs.existsSync(compareDir)) {
+      return NextResponse.json(
+        { success: false, error: "Compare run not found" },
+        { status: 404 }
+      );
+    }
+
+    // Remove the entire compare directory
+    fs.rmSync(compareDir, { recursive: true, force: true });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Failed to delete compare run:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to delete compare run" },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/api/compare/history/route.ts
+++ b/frontend/src/app/api/compare/history/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+
+const OUTPUT_DIR = path.join(process.cwd(), "public", "output");
+const COMPARE_DIR = path.join(OUTPUT_DIR, "compare");
+
+interface ModelInfo {
+  runId: string;
+  model: string;
+  name: string | null;
+}
+
+interface CompareHistoryRun {
+  compareId: string;
+  dataset: string;
+  timestamp: number;
+  name: string | null;
+  mask: number;
+  impute: boolean;
+  models: ModelInfo[];
+}
+
+interface CompareRuntime {
+  compare_id: string;
+  dataset: string;
+  mask: number;
+  impute: boolean;
+  name: string | null;
+  models: Array<{ runId: string; model: string }>;
+}
+
+interface TrainRuntime {
+  name?: string;
+}
+
+function getModelName(runId: string): string | null {
+  try {
+    const runtimePath = path.join(OUTPUT_DIR, runId, "runtime.json");
+    if (fs.existsSync(runtimePath)) {
+      const content = fs.readFileSync(runtimePath, "utf-8");
+      const runtime: TrainRuntime = JSON.parse(content);
+      return runtime.name || null;
+    }
+  } catch {
+    // Ignore errors
+  }
+  return null;
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const searchParams = request.nextUrl.searchParams;
+  const datasetFilter = searchParams.get("dataset");
+
+  try {
+    // Check if compare directory exists
+    if (!fs.existsSync(COMPARE_DIR)) {
+      return NextResponse.json({ runs: [] });
+    }
+
+    // List all compare directories
+    const entries = fs.readdirSync(COMPARE_DIR, { withFileTypes: true });
+    const runs: CompareHistoryRun[] = [];
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+
+      // Validate directory name is a 10-digit timestamp
+      if (!/^\d{10}$/.test(entry.name)) continue;
+
+      const runtimePath = path.join(COMPARE_DIR, entry.name, "runtime.json");
+      if (!fs.existsSync(runtimePath)) continue;
+
+      try {
+        const content = fs.readFileSync(runtimePath, "utf-8");
+        const runtime: CompareRuntime = JSON.parse(content);
+
+        // Filter by dataset if specified
+        if (datasetFilter && runtime.dataset !== datasetFilter) continue;
+
+        // Enrich model info with names from train runs
+        const models: ModelInfo[] = runtime.models.map((m) => ({
+          runId: m.runId,
+          model: m.model,
+          name: getModelName(m.runId),
+        }));
+
+        runs.push({
+          compareId: entry.name,
+          dataset: runtime.dataset,
+          timestamp: parseInt(entry.name, 10),
+          name: runtime.name || null,
+          mask: runtime.mask || 0,
+          impute: runtime.impute || false,
+          models,
+        });
+      } catch {
+        // Skip invalid entries
+      }
+    }
+
+    // Sort by timestamp descending (newest first)
+    runs.sort((a, b) => b.timestamp - a.timestamp);
+
+    return NextResponse.json({ runs });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to list compare history" },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/api/compare/rename/route.ts
+++ b/frontend/src/app/api/compare/rename/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+
+const OUTPUT_DIR = path.join(process.cwd(), "public", "output");
+const COMPARE_DIR = path.join(OUTPUT_DIR, "compare");
+const NAME_PATTERN = /^[a-zA-Z0-9_.\s-]*$/;
+const MAX_LENGTH = 50;
+
+interface RenameRequest {
+  compareId: string;
+  name: string | null;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const body: RenameRequest = await request.json();
+    const { compareId, name } = body;
+
+    if (!compareId || !/^\d{10}$/.test(compareId)) {
+      return NextResponse.json(
+        { error: "Invalid compare ID" },
+        { status: 400 }
+      );
+    }
+
+    // Validate name if provided
+    if (name !== null && name !== "") {
+      if (!NAME_PATTERN.test(name)) {
+        return NextResponse.json(
+          {
+            error:
+              "Name must contain only alphanumeric characters, hyphens, underscores, dots, and spaces",
+          },
+          { status: 400 }
+        );
+      }
+
+      if (name.length > MAX_LENGTH) {
+        return NextResponse.json(
+          { error: `Name must be ${MAX_LENGTH} characters or less` },
+          { status: 400 }
+        );
+      }
+    }
+
+    const compareDir = path.join(COMPARE_DIR, compareId);
+    if (!fs.existsSync(compareDir)) {
+      return NextResponse.json(
+        { error: "Compare run not found" },
+        { status: 404 }
+      );
+    }
+
+    const runtimePath = path.join(compareDir, "runtime.json");
+    if (!fs.existsSync(runtimePath)) {
+      return NextResponse.json(
+        { error: "runtime.json not found" },
+        { status: 404 }
+      );
+    }
+
+    // Read current runtime.json
+    const runtimeContent = fs.readFileSync(runtimePath, "utf-8");
+    const runtime = JSON.parse(runtimeContent);
+
+    // Update name (convert spaces to underscores, empty string or null clears the name)
+    const sanitizedName =
+      name === null || name === "" ? null : name.trim().replace(/ /g, "_");
+    runtime.name = sanitizedName;
+
+    // Write updated runtime.json
+    fs.writeFileSync(runtimePath, JSON.stringify(runtime, null, 2));
+
+    return NextResponse.json({ success: true, name: sanitizedName });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to rename compare run" },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/components/CompareHistoryModal.tsx
+++ b/frontend/src/components/CompareHistoryModal.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { useState } from 'react';
+import { Modal, Spinner } from './ui';
+import type { CompareHistoryRun } from '@/hooks/useCompare';
+
+function formatTimeAgo(timestamp: number): string {
+  const now = Math.floor(Date.now() / 1000);
+  const diff = now - timestamp;
+
+  if (diff < 60) return 'just now';
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  if (diff < 604800) return `${Math.floor(diff / 86400)}d ago`;
+  return new Date(timestamp * 1000).toLocaleDateString();
+}
+
+function formatModelName(model: { runId: string; name: string | null }): string {
+  if (model.name) {
+    return model.name.replace(/_/g, ' ');
+  }
+  return model.runId;
+}
+
+const MODEL_LABELS: Record<string, string> = {
+  'tree': 'Tree',
+  'forest': 'Forest',
+  'gradient': 'Gradient',
+  'hist-gradient': 'Hist Gradient',
+};
+
+interface CompareHistoryModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  runs: CompareHistoryRun[];
+  isLoading: boolean;
+  onSelect: (compareId: string) => void;
+  onDelete: (compareId: string) => Promise<boolean>;
+  onRefresh: () => void;
+}
+
+export function CompareHistoryModal({
+  isOpen,
+  onClose,
+  runs,
+  isLoading,
+  onSelect,
+  onDelete,
+  onRefresh,
+}: CompareHistoryModalProps) {
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const handleDelete = async (e: React.MouseEvent, compareId: string) => {
+    e.stopPropagation();
+    setDeletingId(compareId);
+    const success = await onDelete(compareId);
+    if (success) {
+      onRefresh();
+    }
+    setDeletingId(null);
+  };
+
+  const handleSelect = (compareId: string) => {
+    onSelect(compareId);
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Compare History" maxWidth="4xl">
+      {isLoading ? (
+        <div className="flex items-center justify-center py-12">
+          <Spinner className="h-6 w-6" />
+          <span className="ml-3 text-gray-500">Loading history...</span>
+        </div>
+      ) : runs.length === 0 ? (
+        <div className="text-center py-12 text-gray-500">
+          <p>No compare history found for this dataset.</p>
+          <p className="text-sm mt-2">Run a comparison to create history.</p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {runs.map((run) => (
+            <div
+              key={run.compareId}
+              onClick={() => handleSelect(run.compareId)}
+              className="p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:bg-blue-50/50 cursor-pointer transition-colors"
+            >
+              <div className="flex items-start justify-between">
+                <div className="flex-1 min-w-0">
+                  {/* Header: Name/ID and timestamp */}
+                  <div className="flex items-center gap-3 mb-2">
+                    <span className="font-medium text-gray-900">
+                      {run.name ? run.name.replace(/_/g, ' ') : run.compareId}
+                    </span>
+                    <span className="text-sm text-gray-500">
+                      {formatTimeAgo(run.timestamp)}
+                    </span>
+                    {run.mask > 0 && (
+                      <span className="text-xs px-2 py-0.5 bg-amber-100 text-amber-700 rounded">
+                        mask: {run.mask}%
+                      </span>
+                    )}
+                    {run.impute && (
+                      <span className="text-xs px-2 py-0.5 bg-blue-100 text-blue-700 rounded">
+                        imputed
+                      </span>
+                    )}
+                  </div>
+
+                  {/* Model list - dynamic based on array */}
+                  <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+                    {run.models.map((model, idx) => (
+                      <div key={idx} className="flex items-center gap-2">
+                        <span className="text-gray-500 w-28">
+                          {MODEL_LABELS[model.model] || model.model}:
+                        </span>
+                        <span className="text-gray-700 truncate">
+                          {formatModelName(model)}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Delete button */}
+                <button
+                  onClick={(e) => handleDelete(e, run.compareId)}
+                  disabled={deletingId === run.compareId}
+                  className="ml-4 p-2 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded transition-colors"
+                  title="Delete compare run"
+                >
+                  {deletingId === run.compareId ? (
+                    <Spinner className="h-4 w-4" />
+                  ) : (
+                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                    </svg>
+                  )}
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/frontend/src/components/TrainHistoryModal.tsx
+++ b/frontend/src/components/TrainHistoryModal.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { Modal, Spinner } from './ui';
+import type { DatasetId } from '@/types/dataset';
+import type { ModelId } from '@/types/model';
+import { MODELS } from '@/types/model';
+
+interface HistoryRun {
+  runId: string;
+  model: string;
+  dataset: string;
+  accuracy: number;
+  timestamp: number;
+  name?: string;
+}
+
+function formatTimeAgo(timestamp: number): string {
+  const now = Math.floor(Date.now() / 1000);
+  const diff = now - timestamp;
+
+  if (diff < 60) return 'just now';
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  if (diff < 604800) return `${Math.floor(diff / 86400)}d ago`;
+  return new Date(timestamp * 1000).toLocaleDateString();
+}
+
+function getAccuracyColor(accuracy: number) {
+  if (accuracy >= 0.9) return 'text-green-600';
+  if (accuracy >= 0.8) return 'text-yellow-500';
+  if (accuracy >= 0.7) return 'text-orange-500';
+  if (accuracy >= 0.5) return 'text-red-600';
+  return 'text-blue-900';
+}
+
+interface TrainHistoryModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  dataset: DatasetId;
+  model: ModelId;
+  onSelect: (runId: string) => void;
+}
+
+export function TrainHistoryModal({
+  isOpen,
+  onClose,
+  dataset,
+  model,
+  onSelect,
+}: TrainHistoryModalProps) {
+  const [history, setHistory] = useState<HistoryRun[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const fetchHistory = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const res = await fetch(`/api/history?model=${model}&dataset=${dataset}`);
+      const data = await res.json();
+      setHistory(data.runs || []);
+    } catch {
+      setHistory([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [model, dataset]);
+
+  useEffect(() => {
+    if (isOpen) {
+      fetchHistory();
+      setDeleteConfirmId(null);
+    }
+  }, [isOpen, fetchHistory]);
+
+  const handleRunClick = (runId: string) => {
+    onSelect(runId);
+    onClose();
+  };
+
+  const handleDeleteClick = (e: React.MouseEvent, run: HistoryRun) => {
+    e.stopPropagation();
+
+    if (run.name) {
+      setDeleteConfirmId(run.runId);
+    } else {
+      performDelete(run.runId);
+    }
+  };
+
+  const handleCancelDelete = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setDeleteConfirmId(null);
+  };
+
+  const handleConfirmDelete = (e: React.MouseEvent, runId: string) => {
+    e.stopPropagation();
+    performDelete(runId);
+  };
+
+  const performDelete = async (runId: string) => {
+    setDeletingId(runId);
+    setDeleteConfirmId(null);
+
+    const previousHistory = [...history];
+    setHistory(history.filter(run => run.runId !== runId));
+
+    try {
+      const res = await fetch(`/api/history/${runId}`, { method: 'DELETE' });
+      const data = await res.json();
+
+      if (!data.success) {
+        setHistory(previousHistory);
+      }
+    } catch {
+      setHistory(previousHistory);
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={`${MODELS[model].name} History - ${dataset}`}
+      maxWidth="lg"
+      fitContent
+    >
+      {isLoading ? (
+        <div className="flex justify-center py-8">
+          <Spinner className="h-6 w-6" />
+        </div>
+      ) : history.length === 0 ? (
+        <div className="text-center py-8 text-gray-500">
+          No history found
+        </div>
+      ) : (
+        <div className="max-h-[60vh] overflow-y-auto">
+          <table className="w-full">
+            <thead className="sticky top-0 bg-white">
+              <tr className="border-b border-gray-200 text-xs font-medium text-gray-500">
+                <th className="text-left px-3 py-2 font-medium">Name/ID</th>
+                <th className="text-right px-3 py-2 font-medium w-[70px]">Accuracy</th>
+                <th className="text-right px-3 py-2 font-medium w-[90px]">Time</th>
+                <th className="text-center px-1 py-2 font-medium w-[44px]"><span className="sr-only">Delete</span></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {history.map((run) => {
+                const isConfirming = deleteConfirmId === run.runId;
+                const isDeleting = deletingId === run.runId;
+
+                return (
+                  <tr
+                    key={run.runId}
+                    onClick={() => !isConfirming && handleRunClick(run.runId)}
+                    className={`transition-colors ${
+                      isConfirming ? 'bg-red-50' : 'hover:bg-gray-50 cursor-pointer'
+                    }`}
+                  >
+                    <td className="px-3 py-2 font-mono text-sm text-gray-700 whitespace-nowrap">
+                      {run.name ? run.name.replace(/_/g, " ") : run.runId}
+                    </td>
+
+                    <td className={`px-3 py-2 text-right font-semibold ${getAccuracyColor(run.accuracy)}`}>
+                      {(run.accuracy * 100).toFixed(2)}%
+                    </td>
+
+                    {isConfirming ? (
+                      <td colSpan={2} className="px-3 py-2">
+                        <div className="flex items-center justify-end gap-2">
+                          <span className="text-sm text-red-600">Delete?</span>
+                          <button
+                            type="button"
+                            onClick={handleCancelDelete}
+                            className="px-2 py-1 text-xs font-medium text-gray-600 bg-gray-100 rounded hover:bg-gray-200"
+                          >
+                            Cancel
+                          </button>
+                          <button
+                            type="button"
+                            onClick={(e) => handleConfirmDelete(e, run.runId)}
+                            className="px-2 py-1 text-xs font-medium text-white bg-red-600 rounded hover:bg-red-700"
+                          >
+                            Confirm
+                          </button>
+                        </div>
+                      </td>
+                    ) : (
+                      <>
+                        <td className="px-3 py-2 text-right text-sm text-gray-400 whitespace-nowrap">
+                          {formatTimeAgo(run.timestamp)}
+                        </td>
+
+                        <td className="px-1 py-2 text-center">
+                          <button
+                            type="button"
+                            onClick={(e) => handleDeleteClick(e, run)}
+                            disabled={isDeleting}
+                            className="p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded transition-colors disabled:opacity-50"
+                            title="Delete run"
+                          >
+                            {isDeleting ? (
+                              <Spinner className="h-4 w-4" />
+                            ) : (
+                              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                              </svg>
+                            )}
+                          </button>
+                        </td>
+                      </>
+                    )}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -8,3 +8,5 @@ export { TrainButton } from './TrainButton';
 export { ResultsDisplay, ImagesDisplay } from './ResultsDisplay';
 export { ErrorDisplay } from './ErrorDisplay';
 export { CompareModelsList, CompareButton, CompareResults, ModelRow } from './Compare';
+export { CompareHistoryModal } from './CompareHistoryModal';
+export { TrainHistoryModal } from './TrainHistoryModal';

--- a/frontend/src/components/ui/Tabs.tsx
+++ b/frontend/src/components/ui/Tabs.tsx
@@ -44,26 +44,34 @@ interface ControlledTabsProps {
   activeTab: string;
   onTabChange: (tabId: string) => void;
   children?: React.ReactNode;
+  rightContent?: React.ReactNode;
 }
 
-export function ControlledTabs({ tabs, activeTab, onTabChange, children }: ControlledTabsProps) {
+export function ControlledTabs({ tabs, activeTab, onTabChange, children, rightContent }: ControlledTabsProps) {
   return (
     <div>
-      <div className="flex border-b border-gray-200 mb-4">
-        {tabs.map((tab) => (
-          <button
-            key={tab.id}
-            type="button"
-            onClick={() => onTabChange(tab.id)}
-            className={`px-4 py-2 text-sm font-medium transition-colors ${
-              activeTab === tab.id
-                ? 'text-blue-600 border-b-2 border-blue-600 -mb-px'
-                : 'text-gray-500 hover:text-gray-700'
-            }`}
-          >
-            {tab.label}
-          </button>
-        ))}
+      <div className="flex items-center border-b border-gray-200 mb-4">
+        <div className="flex">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => onTabChange(tab.id)}
+              className={`px-4 py-2 text-sm font-medium transition-colors ${
+                activeTab === tab.id
+                  ? 'text-blue-600 border-b-2 border-blue-600 -mb-px'
+                  : 'text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+        {rightContent && (
+          <div className="ml-auto">
+            {rightContent}
+          </div>
+        )}
       </div>
       {children}
     </div>

--- a/specs/CompareHistory.md
+++ b/specs/CompareHistory.md
@@ -1,0 +1,203 @@
+# Compare History
+
+## Overview
+Enable compare runs to be persisted and browsable like model training runs. Each compare run saves its results and runtime parameters, allowing users to revisit past comparisons via `compare_id` in the URL. Users can rename compare runs, and a history modal displays past comparisons with their IDs and compared model names.
+
+## Requirements
+- Running `compare.py` with model IDs saves `results.json` and `runtime.json` to the compare output directory
+- Compare runs are accessible via `?compare_id=<id>` URL parameter
+- Navigating to Compare mode does NOT auto-load the latest `compare_id` (unlike Train mode which loads latest `run_id`)
+- Users can rename compare runs; the name is stored in `runtime.json`
+- History modal for compare runs shows:
+  - Compare ID (timestamp)
+  - Optional user-defined name
+  - List of compared model names/IDs (array format supporting arbitrary models)
+
+## Implementation Details
+
+### Output Files (compare.py)
+When running in Model ID mode, `compare.py` saves two JSON files to `frontend/public/output/compare/<compare_id>/`:
+
+#### `results.json`
+Contains accuracy statistics and comparison results:
+```json
+{
+  "compareId": "1706540999",
+  "mask": 10,
+  "impute": false,
+  "dataset": "Iris",
+  "models": [
+    {
+      "runId": "1706540123",
+      "model": "tree",
+      "columns": [0, 2, 3],
+      "trainAccuracy": 0.96,
+      "compareAccuracy": 0.92,
+      "imputed": false
+    },
+    {
+      "runId": "1706540456",
+      "model": "forest",
+      "columns": [2, 3],
+      "trainAccuracy": 0.98,
+      "compareAccuracy": 0.95,
+      "imputed": false
+    }
+  ]
+}
+```
+
+#### `runtime.json`
+Contains runtime parameters used for the comparison:
+```json
+{
+  "compare_id": "1706540999",
+  "dataset": "Iris",
+  "mask": 10,
+  "impute": false,
+  "name": null,
+  "models": [
+    { "runId": "1706540123", "model": "tree" },
+    { "runId": "1706540456", "model": "forest" }
+  ]
+}
+```
+
+The `name` field is initially `null` and updated when the user renames the compare run.
+
+### Frontend URL Routing
+- URL parameter: `?compare_id=<id>` (separate from `run_id`)
+- When `compare_id` is present and mode is Compare:
+  - Load `results.json` and `runtime.json` from compare directory
+  - Populate comparison results display
+  - Show compare run name/ID in header
+- When navigating to Compare mode without `compare_id`:
+  - Do NOT auto-load the latest compare run
+  - Show empty state: "Add models to compare and click Compare Models"
+  - User must manually select models or choose from compare history
+
+### Compare History API
+
+#### `GET /api/compare/history`
+Lists all compare runs for a dataset.
+
+Query params:
+- `dataset` (optional): Filter by dataset name
+
+Response:
+```json
+{
+  "runs": [
+    {
+      "compareId": "1706540999",
+      "dataset": "Iris",
+      "timestamp": 1706540999,
+      "name": "Best models v1",
+      "mask": 10,
+      "impute": false,
+      "models": [
+        { "runId": "1706540123", "model": "tree", "name": "Tree v1" },
+        { "runId": "1706540456", "model": "forest", "name": null }
+      ]
+    }
+  ]
+}
+```
+
+The API reads compare directories, parses their `runtime.json`, and enriches model info with names from model `runtime.json` files.
+
+#### `DELETE /api/compare/history/[compareId]`
+Deletes a compare run by removing its directory.
+
+Response:
+```json
+{
+  "success": true
+}
+```
+
+### History Button
+A "History" link in the top right corner of the Train/Compare tabs card:
+- In Compare mode: opens CompareHistoryModal, fetches fresh compare history on click
+- In Train mode: opens TrainHistoryModal for the current model/dataset
+
+### Compare History Modal
+A modal showing past comparison runs.
+
+Display for each entry:
+- Compare ID (or name if set)
+- Timestamp (formatted as "X ago" or date)
+- Mask percentage and impute status badges
+- Model list showing each model type with its name or ID (array format)
+
+Actions:
+- Click to load the compare run (directly loads data and updates URL to `?compare_id=<id>`)
+- Delete button to remove compare run
+
+### Train History Modal
+A modal showing past training runs for the current model/dataset combination:
+- Same functionality as the previous ModelSelector history, but as a standalone modal
+- Accessible via the same History button when in Train mode
+
+### Rename Compare Run
+
+#### `POST /api/compare/rename`
+Renames a compare run.
+
+Request body:
+```json
+{
+  "compareId": "1706540999",
+  "name": "Best_models_v1"
+}
+```
+
+Response:
+```json
+{
+  "success": true
+}
+```
+
+Updates the `name` field in `runtime.json`. Name rules:
+- Spaces converted to underscores
+- Max 50 characters
+- Empty string or null clears the name
+
+### Frontend Integration
+
+#### useCompare Hook Updates
+Add to the hook:
+- `compareHistory`: Array of past compare runs
+- `isLoadingCompareHistory`: Loading state
+- `fetchCompareHistory()`: Fetch compare history (called when History button pressed)
+- `deleteCompareRun(compareId)`: Delete a compare run
+- `renameCompareRun(compareId, name)`: Rename a compare run
+- `setCompareResult`: Allow setting compare result directly (for loading from history)
+
+#### Page Component Updates
+- Read `compare_id` from URL search params
+- When `compare_id` present in Compare mode, load that comparison
+- Show compare run name/ID in header (similar to train run display)
+- Add rename functionality for compare runs (click name to edit)
+- History button in Train/Compare tabs card opens appropriate modal
+- Selecting from history directly loads data (not just URL navigation)
+
+#### CompareHistoryModal Component
+New component (`src/components/CompareHistoryModal.tsx`) showing list of past comparisons:
+- Receives runs from parent (fetched via `fetchCompareHistory`)
+- Each row shows: name/ID, timestamp, mask/impute badges, model names (array format)
+- Click row to load that compare run directly
+- Delete button per row
+
+#### TrainHistoryModal Component
+New component (`src/components/TrainHistoryModal.tsx`) for train run history:
+- Replaces the history functionality previously in ModelSelector
+- Shows runs for current model/dataset combination
+- Click row to navigate to that run
+
+#### ControlledTabs Component Update
+Added `rightContent` prop to place content (like History button) in the top right corner of the tabs bar.
+
+## Related specs
+- [Compare](Compare.md) - Parent spec for compare functionality


### PR DESCRIPTION
## Summary
- Add persistence for compare runs with `results.json` and `runtime.json` saved to `frontend/public/output/compare/<compare_id>/`
- Add `compare_id` URL parameter support for loading past comparisons
- Add History button in Train/Compare tabs card (top right corner)
- Add CompareHistoryModal showing past comparisons with model names, timestamps, and mask/impute badges
- Add TrainHistoryModal as standalone modal for train run history
- Add rename functionality for compare runs (click name to edit)
- Add API routes: `GET /api/compare/history`, `DELETE /api/compare/history/[compareId]`, `POST /api/compare/rename`
- Add `rightContent` prop to ControlledTabs component
- Update useCompare hook with compare history state and functions