### PR TITLE
feat: improve compare history modal with model count emojis

### DIFF
--- a/frontend/src/app/api/compare/history/route.ts
+++ b/frontend/src/app/api/compare/history/route.ts
@@ -18,6 +18,7 @@ interface CompareHistoryRun {
   name: string | null;
   mask: number;
   impute: boolean;
+  sequence: boolean;
   models: ModelInfo[];
 }
 
@@ -26,6 +27,7 @@ interface CompareRuntime {
   dataset: string;
   mask: number;
   impute: boolean;
+  sequence: boolean;
   name: string | null;
   models: Array<{ runId: string; model: string }>;
 }
@@ -92,6 +94,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
           name: runtime.name || null,
           mask: runtime.mask || 0,
           impute: runtime.impute || false,
+          sequence: runtime.sequence || false,
           models,
         });
       } catch {

--- a/frontend/src/app/api/compare/route.ts
+++ b/frontend/src/app/api/compare/route.ts
@@ -93,18 +93,9 @@ async function executeScript(args: string[]): Promise<ScriptResult> {
       stderr += data.toString();
     });
 
-    child.on("close", (code, signal) => {
+    child.on("close", (code) => {
       if (code === 0) {
         resolve({ stdout, stderr, code });
-      } else if (signal) {
-        reject(
-          new CompareError(
-            `Compare script was killed by signal ${signal}`,
-            "SCRIPT_EXECUTION_ERROR",
-            stderr || stdout || `Process killed by ${signal}`,
-            extractStackTrace(stderr),
-          ),
-        );
       } else {
         reject(
           new CompareError(

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -101,6 +101,7 @@ function HomeContent() {
     removeModel,
     updateModelType,
     updateModelRun,
+    duplicateRunIds,
     datasetParams: compareDatasetParams,
     setDatasetParams: setCompareDatasetParams,
     resetDatasetParams: resetCompareDatasetParams,
@@ -262,6 +263,22 @@ function HomeContent() {
 
           if (resultData.params) {
             trainResult.params = resultData.params;
+          }
+
+          if (resultData.train_data) {
+            trainResult.trainData = resultData.train_data;
+          }
+
+          if (resultData.test_data) {
+            trainResult.testData = resultData.test_data;
+          }
+
+          if (resultData.train_labels) {
+            trainResult.trainLabels = resultData.train_labels;
+          }
+
+          if (resultData.test_labels) {
+            trainResult.testLabels = resultData.test_labels;
           }
 
           if (resultData.feature_names) {
@@ -821,12 +838,16 @@ function HomeContent() {
                   <CompareModelsList
                     models={compareModels}
                     history={compareHistory}
+                    duplicateRunIds={duplicateRunIds}
                     onRemoveModel={removeModel}
                     onUpdateModelType={updateModelType}
                     onUpdateModelRun={updateModelRun}
                     isLoadingHistory={isLoadingHistory}
                     onAddAllModels={addAllModels}
                     onClearAllModels={clearAllModels}
+                    onCompare={runCompare}
+                    isComparing={isComparing}
+                    canCompare={canCompare}
                   />
                 </div>
               ) : (

--- a/frontend/src/components/CompareDatasetParams.tsx
+++ b/frontend/src/components/CompareDatasetParams.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Slider, Checkbox, Button, ImputeCheckbox, SequenceCheckbox } from './ui';
+import { Slider, Checkbox, Button, ImputeCheckbox } from './ui';
 import type { CompareDatasetParams as CompareDatasetParamsType } from '@/hooks/useCompare';
 import type { DatasetId } from '@/types/dataset';
 import { DATASETS } from '@/types/dataset';
@@ -64,40 +64,56 @@ export function CompareDatasetParams({ params, dataset, onChange, onReset, disab
     }
   };
 
+  const modeOptions = [
+    { value: 'compare', label: 'Compare' },
+    { value: 'sequence', label: 'Sequence' },
+  ];
+
   return (
     <div>
       <div className="flex items-center justify-between mb-4">
-        <h3 className="text-sm font-medium text-gray-700">Dataset Parameters</h3>
+        <div className="flex items-center gap-3">
+          <h3 className="text-sm font-medium text-gray-700">Dataset Parameters</h3>
+          <div className="flex items-center gap-2 whitespace-nowrap">
+            <span className="text-sm font-medium text-gray-700">Mode:</span>
+            <select
+              value={params.sequence ? 'sequence' : 'compare'}
+              onChange={(e) => onChange({ sequence: e.target.value === 'sequence' })}
+              disabled={disabled}
+              className="rounded-lg border border-gray-300 bg-white px-2 py-1 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-50"
+            >
+              {modeOptions.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </div>
+        </div>
         <Button type="button" variant="ghost" size="sm" onClick={onReset} disabled={disabled}>
           Reset
         </Button>
       </div>
 
       <div className="space-y-4">
-        <Slider
-          label="Mask Rate"
-          value={params.mask}
-          onChange={(mask) => onChange({ mask })}
-          min={0}
-          max={100}
-          step={5}
-          unit="%"
-          disabled={disabled || params.sequence}
-          action={
-            <ImputeCheckbox
-              mask={params.mask}
-              impute={params.impute}
-              onChange={(impute) => onChange({ impute })}
-              disabled={disabled || params.sequence}
-            />
-          }
-        />
-
-        <SequenceCheckbox
-          checked={params.sequence}
-          onChange={(sequence) => onChange({ sequence })}
-          disabled={disabled}
-        />
+        {!params.sequence && (
+          <Slider
+            label="Mask Rate"
+            value={params.mask}
+            onChange={(mask) => onChange({ mask })}
+            min={0}
+            max={100}
+            step={5}
+            unit="%"
+            disabled={disabled}
+            action={
+              <ImputeCheckbox
+                mask={params.mask}
+                impute={params.impute}
+                onChange={(impute) => onChange({ impute })}
+                disabled={disabled}
+              />
+            }
+          />
+        )}
 
         {!hideColumns && (
           <div>

--- a/frontend/src/components/ModelParams.tsx
+++ b/frontend/src/components/ModelParams.tsx
@@ -1,15 +1,9 @@
-"use client";
+'use client';
 
-import { Select, Input, Checkbox, Button } from "./ui";
-import type { ModelId } from "@/types/model";
-import type {
-  TreeParams,
-  ForestParams,
-  GradientParams,
-  HistGradientParams,
-  ModelParams as ModelParamsType,
-} from "@/types/params";
-import { MODELS } from "@/types/model";
+import { Select, Input, Checkbox, Button } from './ui';
+import type { ModelId } from '@/types/model';
+import type { TreeParams, ForestParams, GradientParams, HistGradientParams, ModelParams as ModelParamsType } from '@/types/params';
+import { MODELS } from '@/types/model';
 
 interface ModelParamsProps {
   model: ModelId;
@@ -19,57 +13,29 @@ interface ModelParamsProps {
   disabled?: boolean;
 }
 
-export function ModelParams({
-  model,
-  params,
-  onChange,
-  onReset,
-  disabled,
-}: ModelParamsProps) {
+export function ModelParams({ model, params, onChange, onReset, disabled }: ModelParamsProps) {
   return (
     <div>
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-sm font-medium text-gray-700">
           Model Parameters ({MODELS[model].name})
         </h3>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={onReset}
-          disabled={disabled}
-        >
+        <Button type="button" variant="ghost" size="sm" onClick={onReset} disabled={disabled}>
           Reset
         </Button>
       </div>
 
-      {model === "tree" && (
-        <TreeParamsForm
-          params={params as TreeParams}
-          onChange={onChange}
-          disabled={disabled}
-        />
+      {model === 'tree' && (
+        <TreeParamsForm params={params as TreeParams} onChange={onChange} disabled={disabled} />
       )}
-      {model === "forest" && (
-        <ForestParamsForm
-          params={params as ForestParams}
-          onChange={onChange}
-          disabled={disabled}
-        />
+      {model === 'forest' && (
+        <ForestParamsForm params={params as ForestParams} onChange={onChange} disabled={disabled} />
       )}
-      {model === "gradient" && (
-        <GradientParamsForm
-          params={params as GradientParams}
-          onChange={onChange}
-          disabled={disabled}
-        />
+      {model === 'gradient' && (
+        <GradientParamsForm params={params as GradientParams} onChange={onChange} disabled={disabled} />
       )}
-      {model === "hist-gradient" && (
-        <HistGradientParamsForm
-          params={params as HistGradientParams}
-          onChange={onChange}
-          disabled={disabled}
-        />
+      {model === 'hist-gradient' && (
+        <HistGradientParamsForm params={params as HistGradientParams} onChange={onChange} disabled={disabled} />
       )}
     </div>
   );
@@ -88,11 +54,11 @@ function TreeParamsForm({ params, onChange, disabled }: TreeParamsFormProps) {
         label="Criterion"
         tooltip="Function to measure split quality. Gini is faster, entropy may give slightly better results."
         value={params.criterion}
-        onChange={(v) => onChange({ criterion: v as TreeParams["criterion"] })}
+        onChange={(v) => onChange({ criterion: v as TreeParams['criterion'] })}
         options={[
-          { value: "gini", label: "Gini" },
-          { value: "entropy", label: "Entropy" },
-          { value: "log_loss", label: "Log Loss" },
+          { value: 'gini', label: 'Gini' },
+          { value: 'entropy', label: 'Entropy' },
+          { value: 'log_loss', label: 'Log Loss' },
         ]}
         disabled={disabled}
       />
@@ -101,10 +67,10 @@ function TreeParamsForm({ params, onChange, disabled }: TreeParamsFormProps) {
         label="Splitter"
         tooltip="Strategy to choose the split. Best chooses optimal split, random is faster but less accurate."
         value={params.splitter}
-        onChange={(v) => onChange({ splitter: v as TreeParams["splitter"] })}
+        onChange={(v) => onChange({ splitter: v as TreeParams['splitter'] })}
         options={[
-          { value: "best", label: "Best" },
-          { value: "random", label: "Random" },
+          { value: 'best', label: 'Best' },
+          { value: 'random', label: 'Random' },
         ]}
         disabled={disabled}
       />
@@ -112,16 +78,12 @@ function TreeParamsForm({ params, onChange, disabled }: TreeParamsFormProps) {
       <Select
         label="Max Features"
         tooltip="Number of features to consider for best split. Fewer features = faster but potentially less accurate."
-        value={params.max_features ?? "auto"}
-        onChange={(v) =>
-          onChange({
-            max_features: v === "auto" ? null : (v as "sqrt" | "log2"),
-          })
-        }
+        value={params.max_features ?? 'auto'}
+        onChange={(v) => onChange({ max_features: v === 'auto' ? null : v as 'sqrt' | 'log2' })}
         options={[
-          { value: "auto", label: "Auto (all)" },
-          { value: "sqrt", label: "Square Root" },
-          { value: "log2", label: "Log2" },
+          { value: 'auto', label: 'Auto (all)' },
+          { value: 'sqrt', label: 'Square Root' },
+          { value: 'log2', label: 'Log2' },
         ]}
         disabled={disabled}
       />
@@ -130,8 +92,8 @@ function TreeParamsForm({ params, onChange, disabled }: TreeParamsFormProps) {
         label="Max Depth"
         tooltip="Maximum depth of tree. Deeper trees can overfit. Leave empty for unlimited."
         type="number"
-        value={params.max_depth ?? ""}
-        onChange={(v) => onChange({ max_depth: v === "" ? null : Number(v) })}
+        value={params.max_depth ?? ''}
+        onChange={(v) => onChange({ max_depth: v === '' ? null : Number(v) })}
         placeholder="Unlimited"
         min={1}
         disabled={disabled}
@@ -141,10 +103,8 @@ function TreeParamsForm({ params, onChange, disabled }: TreeParamsFormProps) {
         label="Max Leaf Nodes"
         tooltip="Maximum number of leaf nodes. Limits tree complexity. Leave empty for unlimited."
         type="number"
-        value={params.max_leaf_nodes ?? ""}
-        onChange={(v) =>
-          onChange({ max_leaf_nodes: v === "" ? null : Number(v) })
-        }
+        value={params.max_leaf_nodes ?? ''}
+        onChange={(v) => onChange({ max_leaf_nodes: v === '' ? null : Number(v) })}
         placeholder="Unlimited"
         min={2}
         disabled={disabled}
@@ -177,7 +137,7 @@ function TreeParamsForm({ params, onChange, disabled }: TreeParamsFormProps) {
         value={params.min_impurity_decrease}
         onChange={(v) => onChange({ min_impurity_decrease: Number(v) || 0 })}
         min={0}
-        step={0.01}
+        step={0.001}
         disabled={disabled}
       />
 
@@ -188,20 +148,18 @@ function TreeParamsForm({ params, onChange, disabled }: TreeParamsFormProps) {
         value={params.ccp_alpha}
         onChange={(v) => onChange({ ccp_alpha: Number(v) || 0 })}
         min={0}
-        step={0.01}
+        step={0.001}
         disabled={disabled}
       />
 
       <Select
         label="Class Weight"
         tooltip="Weight classes inversely proportional to frequency. Useful for imbalanced datasets."
-        value={params.class_weight ?? "none"}
-        onChange={(v) =>
-          onChange({ class_weight: v === "none" ? null : (v as "balanced") })
-        }
+        value={params.class_weight ?? 'none'}
+        onChange={(v) => onChange({ class_weight: v === 'none' ? null : v as 'balanced' })}
         options={[
-          { value: "none", label: "None" },
-          { value: "balanced", label: "Balanced" },
+          { value: 'none', label: 'None' },
+          { value: 'balanced', label: 'Balanced' },
         ]}
         disabled={disabled}
       />
@@ -215,11 +173,7 @@ interface ForestParamsFormProps {
   disabled?: boolean;
 }
 
-function ForestParamsForm({
-  params,
-  onChange,
-  disabled,
-}: ForestParamsFormProps) {
+function ForestParamsForm({ params, onChange, disabled }: ForestParamsFormProps) {
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -237,13 +191,11 @@ function ForestParamsForm({
           label="Criterion"
           tooltip="Function to measure split quality. Gini is faster, entropy may give slightly better results."
           value={params.criterion}
-          onChange={(v) =>
-            onChange({ criterion: v as ForestParams["criterion"] })
-          }
+          onChange={(v) => onChange({ criterion: v as ForestParams['criterion'] })}
           options={[
-            { value: "gini", label: "Gini" },
-            { value: "entropy", label: "Entropy" },
-            { value: "log_loss", label: "Log Loss" },
+            { value: 'gini', label: 'Gini' },
+            { value: 'entropy', label: 'Entropy' },
+            { value: 'log_loss', label: 'Log Loss' },
           ]}
           disabled={disabled}
         />
@@ -251,16 +203,12 @@ function ForestParamsForm({
         <Select
           label="Max Features"
           tooltip="Features to consider per split. sqrt is recommended for classification."
-          value={params.max_features ?? "auto"}
-          onChange={(v) =>
-            onChange({
-              max_features: v === "auto" ? null : (v as "sqrt" | "log2"),
-            })
-          }
+          value={params.max_features ?? 'auto'}
+          onChange={(v) => onChange({ max_features: v === 'auto' ? null : v as 'sqrt' | 'log2' })}
           options={[
-            { value: "auto", label: "Auto (all)" },
-            { value: "sqrt", label: "Square Root" },
-            { value: "log2", label: "Log2" },
+            { value: 'auto', label: 'Auto (all)' },
+            { value: 'sqrt', label: 'Square Root' },
+            { value: 'log2', label: 'Log2' },
           ]}
           disabled={disabled}
         />
@@ -269,8 +217,8 @@ function ForestParamsForm({
           label="Max Depth"
           tooltip="Maximum depth of each tree. Shallower trees prevent overfitting."
           type="number"
-          value={params.max_depth ?? ""}
-          onChange={(v) => onChange({ max_depth: v === "" ? null : Number(v) })}
+          value={params.max_depth ?? ''}
+          onChange={(v) => onChange({ max_depth: v === '' ? null : Number(v) })}
           placeholder="Unlimited"
           min={1}
           disabled={disabled}
@@ -280,10 +228,8 @@ function ForestParamsForm({
           label="Max Leaf Nodes"
           tooltip="Maximum leaf nodes per tree. Limits complexity."
           type="number"
-          value={params.max_leaf_nodes ?? ""}
-          onChange={(v) =>
-            onChange({ max_leaf_nodes: v === "" ? null : Number(v) })
-          }
+          value={params.max_leaf_nodes ?? ''}
+          onChange={(v) => onChange({ max_leaf_nodes: v === '' ? null : Number(v) })}
           placeholder="Unlimited"
           min={2}
           disabled={disabled}
@@ -293,10 +239,8 @@ function ForestParamsForm({
           label="Max Samples"
           tooltip="Samples to draw for training each tree. Lower values increase diversity."
           type="number"
-          value={params.max_samples ?? ""}
-          onChange={(v) =>
-            onChange({ max_samples: v === "" ? null : Number(v) })
-          }
+          value={params.max_samples ?? ''}
+          onChange={(v) => onChange({ max_samples: v === '' ? null : Number(v) })}
           placeholder="All"
           min={1}
           disabled={disabled}
@@ -329,7 +273,7 @@ function ForestParamsForm({
           value={params.min_impurity_decrease}
           onChange={(v) => onChange({ min_impurity_decrease: Number(v) || 0 })}
           min={0}
-          step={0.01}
+          step={0.001}
           disabled={disabled}
         />
 
@@ -340,7 +284,7 @@ function ForestParamsForm({
           value={params.ccp_alpha}
           onChange={(v) => onChange({ ccp_alpha: Number(v) || 0 })}
           min={0}
-          step={0.01}
+          step={0.001}
           disabled={disabled}
         />
 
@@ -348,8 +292,8 @@ function ForestParamsForm({
           label="N Jobs"
           tooltip="Parallel jobs for fitting. -1 uses all CPU cores."
           type="number"
-          value={params.n_jobs ?? ""}
-          onChange={(v) => onChange({ n_jobs: v === "" ? null : Number(v) })}
+          value={params.n_jobs ?? ''}
+          onChange={(v) => onChange({ n_jobs: v === '' ? null : Number(v) })}
           placeholder="1 (-1 for all)"
           min={-1}
           disabled={disabled}
@@ -358,17 +302,12 @@ function ForestParamsForm({
         <Select
           label="Class Weight"
           tooltip="Weight classes inversely proportional to frequency. balanced_subsample uses bootstrap sample weights."
-          value={params.class_weight ?? "none"}
-          onChange={(v) =>
-            onChange({
-              class_weight:
-                v === "none" ? null : (v as "balanced" | "balanced_subsample"),
-            })
-          }
+          value={params.class_weight ?? 'none'}
+          onChange={(v) => onChange({ class_weight: v === 'none' ? null : v as 'balanced' | 'balanced_subsample' })}
           options={[
-            { value: "none", label: "None" },
-            { value: "balanced", label: "Balanced" },
-            { value: "balanced_subsample", label: "Balanced Subsample" },
+            { value: 'none', label: 'None' },
+            { value: 'balanced', label: 'Balanced' },
+            { value: 'balanced_subsample', label: 'Balanced Subsample' },
           ]}
           disabled={disabled}
         />
@@ -407,11 +346,7 @@ interface GradientParamsFormProps {
   disabled?: boolean;
 }
 
-function GradientParamsForm({
-  params,
-  onChange,
-  disabled,
-}: GradientParamsFormProps) {
+function GradientParamsForm({ params, onChange, disabled }: GradientParamsFormProps) {
   const earlyStoppingEnabled = params.n_iter_no_change !== null;
 
   return (
@@ -420,10 +355,10 @@ function GradientParamsForm({
         label="Loss"
         tooltip="Loss function. log_loss for multi-class, exponential for AdaBoost-like algorithm (binary only)."
         value={params.loss}
-        onChange={(v) => onChange({ loss: v as GradientParams["loss"] })}
+        onChange={(v) => onChange({ loss: v as GradientParams['loss'] })}
         options={[
-          { value: "log_loss", label: "Log Loss" },
-          { value: "exponential", label: "Exponential" },
+          { value: 'log_loss', label: 'Log Loss' },
+          { value: 'exponential', label: 'Exponential' },
         ]}
         disabled={disabled}
       />
@@ -434,7 +369,7 @@ function GradientParamsForm({
         type="number"
         value={params.learning_rate}
         onChange={(v) => onChange({ learning_rate: Number(v) || 0.1 })}
-        min={0.01}
+        min={0.001}
         max={1}
         step={0.01}
         disabled={disabled}
@@ -458,7 +393,7 @@ function GradientParamsForm({
         onChange={(v) => onChange({ subsample: Number(v) || 1.0 })}
         min={0.01}
         max={1}
-        step={0.01}
+        step={0.05}
         disabled={disabled}
       />
 
@@ -466,12 +401,10 @@ function GradientParamsForm({
         label="Criterion"
         tooltip="Function to measure split quality. friedman_mse is generally preferred."
         value={params.criterion}
-        onChange={(v) =>
-          onChange({ criterion: v as GradientParams["criterion"] })
-        }
+        onChange={(v) => onChange({ criterion: v as GradientParams['criterion'] })}
         options={[
-          { value: "friedman_mse", label: "Friedman MSE" },
-          { value: "squared_error", label: "Squared Error" },
+          { value: 'friedman_mse', label: 'Friedman MSE' },
+          { value: 'squared_error', label: 'Squared Error' },
         ]}
         disabled={disabled}
       />
@@ -489,16 +422,12 @@ function GradientParamsForm({
       <Select
         label="Max Features"
         tooltip="Number of features to consider for best split. Fewer features = faster but potentially less accurate."
-        value={params.max_features ?? "auto"}
-        onChange={(v) =>
-          onChange({
-            max_features: v === "auto" ? null : (v as "sqrt" | "log2"),
-          })
-        }
+        value={params.max_features ?? 'auto'}
+        onChange={(v) => onChange({ max_features: v === 'auto' ? null : v as 'sqrt' | 'log2' })}
         options={[
-          { value: "auto", label: "Auto (all)" },
-          { value: "sqrt", label: "Square Root" },
-          { value: "log2", label: "Log2" },
+          { value: 'auto', label: 'Auto (all)' },
+          { value: 'sqrt', label: 'Square Root' },
+          { value: 'log2', label: 'Log2' },
         ]}
         disabled={disabled}
       />
@@ -507,10 +436,8 @@ function GradientParamsForm({
         label="Max Leaf Nodes"
         tooltip="Maximum number of leaf nodes per tree. Limits tree complexity."
         type="number"
-        value={params.max_leaf_nodes ?? ""}
-        onChange={(v) =>
-          onChange({ max_leaf_nodes: v === "" ? null : Number(v) })
-        }
+        value={params.max_leaf_nodes ?? ''}
+        onChange={(v) => onChange({ max_leaf_nodes: v === '' ? null : Number(v) })}
         placeholder="Unlimited"
         min={2}
         disabled={disabled}
@@ -555,7 +482,7 @@ function GradientParamsForm({
         value={params.min_impurity_decrease}
         onChange={(v) => onChange({ min_impurity_decrease: Number(v) || 0 })}
         min={0}
-        step={0.01}
+        step={0.001}
         disabled={disabled}
       />
 
@@ -566,7 +493,7 @@ function GradientParamsForm({
         value={params.ccp_alpha}
         onChange={(v) => onChange({ ccp_alpha: Number(v) || 0 })}
         min={0}
-        step={0.01}
+        step={0.001}
         disabled={disabled}
       />
 
@@ -574,10 +501,8 @@ function GradientParamsForm({
         label="N Iter No Change"
         tooltip="Iterations without improvement before stopping. Leave empty to disable early stopping."
         type="number"
-        value={params.n_iter_no_change ?? ""}
-        onChange={(v) =>
-          onChange({ n_iter_no_change: v === "" ? null : Number(v) })
-        }
+        value={params.n_iter_no_change ?? ''}
+        onChange={(v) => onChange({ n_iter_no_change: v === '' ? null : Number(v) })}
         placeholder="Disabled"
         min={1}
         disabled={disabled}
@@ -615,13 +540,8 @@ interface HistGradientParamsFormProps {
   disabled?: boolean;
 }
 
-function HistGradientParamsForm({
-  params,
-  onChange,
-  disabled,
-}: HistGradientParamsFormProps) {
-  const earlyStoppingEnabled =
-    params.early_stopping === true || params.early_stopping === "auto";
+function HistGradientParamsForm({ params, onChange, disabled }: HistGradientParamsFormProps) {
+  const earlyStoppingEnabled = params.early_stopping === true || params.early_stopping === 'auto';
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -631,7 +551,7 @@ function HistGradientParamsForm({
         type="number"
         value={params.learning_rate}
         onChange={(v) => onChange({ learning_rate: Number(v) || 0.1 })}
-        min={0.01}
+        min={0.001}
         max={1}
         step={0.01}
         disabled={disabled}
@@ -651,8 +571,8 @@ function HistGradientParamsForm({
         label="Max Depth"
         tooltip="Maximum depth of each tree. Controls model complexity."
         type="number"
-        value={params.max_depth ?? ""}
-        onChange={(v) => onChange({ max_depth: v === "" ? null : Number(v) })}
+        value={params.max_depth ?? ''}
+        onChange={(v) => onChange({ max_depth: v === '' ? null : Number(v) })}
         placeholder="Unlimited"
         min={1}
         disabled={disabled}
@@ -662,10 +582,8 @@ function HistGradientParamsForm({
         label="Max Leaf Nodes"
         tooltip="Maximum leaf nodes per tree. 31 is a common default."
         type="number"
-        value={params.max_leaf_nodes ?? ""}
-        onChange={(v) =>
-          onChange({ max_leaf_nodes: v === "" ? null : Number(v) })
-        }
+        value={params.max_leaf_nodes ?? ''}
+        onChange={(v) => onChange({ max_leaf_nodes: v === '' ? null : Number(v) })}
         placeholder="Unlimited"
         min={2}
         disabled={disabled}
@@ -708,13 +626,13 @@ function HistGradientParamsForm({
         tooltip="Stop training when validation score stops improving. Auto enables for large datasets."
         value={String(params.early_stopping)}
         onChange={(v) => {
-          const value = v === "auto" ? "auto" : v === "true";
+          const value = v === 'auto' ? 'auto' : v === 'true';
           onChange({ early_stopping: value });
         }}
         options={[
-          { value: "false", label: "Off" },
-          { value: "true", label: "On" },
-          { value: "auto", label: "Auto" },
+          { value: 'false', label: 'Off' },
+          { value: 'true', label: 'On' },
+          { value: 'auto', label: 'Auto' },
         ]}
         disabled={disabled}
       />
@@ -755,16 +673,12 @@ function HistGradientParamsForm({
       <Select
         label="Scoring"
         tooltip="Scoring method for early stopping. Loss uses the loss function, accuracy uses classification accuracy."
-        value={params.scoring ?? "auto"}
-        onChange={(v) =>
-          onChange({
-            scoring: v === "auto" ? null : (v as "accuracy" | "loss"),
-          })
-        }
+        value={params.scoring ?? 'auto'}
+        onChange={(v) => onChange({ scoring: v === 'auto' ? null : v as 'accuracy' | 'loss' })}
         options={[
-          { value: "auto", label: "Auto (loss)" },
-          { value: "loss", label: "Loss" },
-          { value: "accuracy", label: "Accuracy" },
+          { value: 'auto', label: 'Auto (loss)' },
+          { value: 'loss', label: 'Loss' },
+          { value: 'accuracy', label: 'Accuracy' },
         ]}
         disabled={disabled || !earlyStoppingEnabled}
       />
@@ -772,13 +686,11 @@ function HistGradientParamsForm({
       <Select
         label="Class Weight"
         tooltip="Weight classes inversely proportional to frequency. Useful for imbalanced datasets."
-        value={params.class_weight ?? "none"}
-        onChange={(v) =>
-          onChange({ class_weight: v === "none" ? null : (v as "balanced") })
-        }
+        value={params.class_weight ?? 'none'}
+        onChange={(v) => onChange({ class_weight: v === 'none' ? null : v as 'balanced' })}
         options={[
-          { value: "none", label: "None" },
-          { value: "balanced", label: "Balanced" },
+          { value: 'none', label: 'None' },
+          { value: 'balanced', label: 'Balanced' },
         ]}
         disabled={disabled}
       />

--- a/frontend/src/components/ResultsDisplay.tsx
+++ b/frontend/src/components/ResultsDisplay.tsx
@@ -213,51 +213,10 @@ function ExpandIcon() {
   );
 }
 
-interface CsvData {
-  data: Record<string, unknown>[];
-  labels: string[];
-  featureNames: string[];
-}
-
-async function loadCsvData(runId: string, type: 'train' | 'test'): Promise<CsvData | null> {
-  try {
-    const response = await fetch(`/output/${runId}/${type}.csv`);
-    if (!response.ok) return null;
-    const text = await response.text();
-    const lines = text.trim().split('\n');
-    if (lines.length < 2) return null;
-
-    const headers = lines[0].split(',');
-    const labelCol = headers[headers.length - 1]; // Last column is label
-    const featureNames = headers.slice(0, -1);
-
-    const data: Record<string, unknown>[] = [];
-    const labels: string[] = [];
-
-    for (let i = 1; i < lines.length; i++) {
-      const values = lines[i].split(',');
-      const row: Record<string, unknown> = {};
-      for (let j = 0; j < featureNames.length; j++) {
-        const val = values[j];
-        row[featureNames[j]] = val === '' ? null : isNaN(Number(val)) ? val : Number(val);
-      }
-      data.push(row);
-      labels.push(values[values.length - 1]);
-    }
-
-    return { data, labels, featureNames };
-  } catch {
-    return null;
-  }
-}
-
 export function ResultsDisplay({ result, isLoading }: ResultsDisplayProps) {
   const { accuracy, classificationReport, modelInfo, featureImportance, executionTime, runId } = result;
   const [datasetView, setDatasetView] = useState<'train' | 'test'>('train');
   const [isFullscreen, setIsFullscreen] = useState(false);
-  const [trainData, setTrainData] = useState<CsvData | null>(null);
-  const [testData, setTestData] = useState<CsvData | null>(null);
-  const [isLoadingDataset, setIsLoadingDataset] = useState(false);
 
   const sortedFeatureImportance = useMemo(() => {
     if (!featureImportance) return [];
@@ -266,26 +225,7 @@ export function ResultsDisplay({ result, isLoading }: ResultsDisplayProps) {
       .sort((a, b) => b.value - a.value);
   }, [featureImportance]);
 
-  // Load CSV data when switching to dataset view
-  useEffect(() => {
-    if (!runId) return;
-
-    const loadData = async () => {
-      setIsLoadingDataset(true);
-      if (datasetView === 'train' && !trainData) {
-        const data = await loadCsvData(runId, 'train');
-        setTrainData(data);
-      } else if (datasetView === 'test' && !testData) {
-        const data = await loadCsvData(runId, 'test');
-        setTestData(data);
-      }
-      setIsLoadingDataset(false);
-    };
-
-    loadData();
-  }, [runId, datasetView, trainData, testData]);
-
-  const hasDataset = !!runId;
+  const hasDataset = result.trainData || result.testData;
 
   return (
     <Card variant="elevated">
@@ -422,7 +362,7 @@ export function ResultsDisplay({ result, isLoading }: ResultsDisplayProps) {
                           : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
                       }`}
                     >
-                      Train {trainData ? `(${trainData.data.length} rows)` : ''}
+                      Train ({result.trainData?.length ?? 0} rows)
                     </button>
                     <button
                       onClick={() => setDatasetView('test')}
@@ -432,7 +372,7 @@ export function ResultsDisplay({ result, isLoading }: ResultsDisplayProps) {
                           : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
                       }`}
                     >
-                      Test {testData ? `(${testData.data.length} rows)` : ''}
+                      Test ({result.testData?.length ?? 0} rows)
                     </button>
                   </div>
                   <button
@@ -445,23 +385,18 @@ export function ResultsDisplay({ result, isLoading }: ResultsDisplayProps) {
                 </div>
 
                 <div className="overflow-x-auto">
-                  {isLoadingDataset && (
-                    <div className="flex justify-center py-8">
-                      <Spinner />
-                    </div>
-                  )}
-                  {!isLoadingDataset && datasetView === 'train' && trainData && (
+                  {datasetView === 'train' && result.trainData && (
                     <DatasetTable
-                      data={trainData.data}
-                      labels={trainData.labels}
-                      featureNames={trainData.featureNames}
+                      data={result.trainData}
+                      labels={result.trainLabels}
+                      featureNames={result.featureNames}
                     />
                   )}
-                  {!isLoadingDataset && datasetView === 'test' && testData && (
+                  {datasetView === 'test' && result.testData && (
                     <DatasetTable
-                      data={testData.data}
-                      labels={testData.labels}
-                      featureNames={testData.featureNames}
+                      data={result.testData}
+                      labels={result.testLabels}
+                      featureNames={result.featureNames}
                     />
                   )}
                 </div>
@@ -481,7 +416,7 @@ export function ResultsDisplay({ result, isLoading }: ResultsDisplayProps) {
                             : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
                         }`}
                       >
-                        Train {trainData ? `(${trainData.data.length} rows)` : ''}
+                        Train ({result.trainData?.length ?? 0} rows)
                       </button>
                       <button
                         onClick={() => setDatasetView('test')}
@@ -491,29 +426,24 @@ export function ResultsDisplay({ result, isLoading }: ResultsDisplayProps) {
                             : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
                         }`}
                       >
-                        Test {testData ? `(${testData.data.length} rows)` : ''}
+                        Test ({result.testData?.length ?? 0} rows)
                       </button>
                     </div>
 
                     <div className="overflow-x-auto">
-                      {isLoadingDataset && (
-                        <div className="flex justify-center py-8">
-                          <Spinner />
-                        </div>
-                      )}
-                      {!isLoadingDataset && datasetView === 'train' && trainData && (
+                      {datasetView === 'train' && result.trainData && (
                         <DatasetTable
-                          data={trainData.data}
-                          labels={trainData.labels}
-                          featureNames={trainData.featureNames}
+                          data={result.trainData}
+                          labels={result.trainLabels}
+                          featureNames={result.featureNames}
                           pageSize={25}
                         />
                       )}
-                      {!isLoadingDataset && datasetView === 'test' && testData && (
+                      {datasetView === 'test' && result.testData && (
                         <DatasetTable
-                          data={testData.data}
-                          labels={testData.labels}
-                          featureNames={testData.featureNames}
+                          data={result.testData}
+                          labels={result.testLabels}
+                          featureNames={result.featureNames}
                           pageSize={25}
                         />
                       )}

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -9,6 +9,7 @@ interface ModalProps {
   children: React.ReactNode;
   maxWidth?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl' | '6xl';
   fitContent?: boolean;
+  minWidth?: number;
 }
 
 const maxWidthClasses = {
@@ -23,7 +24,7 @@ const maxWidthClasses = {
   '6xl': 'max-w-6xl',
 };
 
-export function Modal({ isOpen, onClose, title, children, maxWidth = '6xl', fitContent = false }: ModalProps) {
+export function Modal({ isOpen, onClose, title, children, maxWidth = '6xl', fitContent = false, minWidth }: ModalProps) {
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -56,7 +57,10 @@ export function Modal({ isOpen, onClose, title, children, maxWidth = '6xl', fitC
       />
 
       {/* Modal container */}
-      <div className={`relative bg-white rounded-lg shadow-xl ${fitContent ? '' : `w-full ${maxWidthClasses[maxWidth]}`} max-h-[90vh] m-4 flex flex-col`}>
+      <div
+        className={`relative bg-white rounded-lg shadow-xl ${fitContent ? maxWidthClasses[maxWidth] : `w-full ${maxWidthClasses[maxWidth]}`} max-h-[90vh] m-4 flex flex-col`}
+        style={minWidth ? { minWidth: `${minWidth}px` } : undefined}
+      >
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 shrink-0">
           <h2 className="text-lg font-semibold text-gray-900 whitespace-nowrap">{title}</h2>
@@ -82,7 +86,7 @@ export function Modal({ isOpen, onClose, title, children, maxWidth = '6xl', fitC
         </div>
 
         {/* Body */}
-        <div className={`flex-1 p-6 ${fitContent ? '' : 'overflow-auto'}`}>
+        <div className="flex-1 p-6 overflow-auto">
           {children}
         </div>
       </div>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -56,6 +56,10 @@ export interface TrainResult {
   modelInfo?: ModelInfo;
   featureImportance?: Record<string, number>;
   params?: TrainParams;
+  trainData?: Record<string, unknown>[];
+  testData?: Record<string, unknown>[];
+  trainLabels?: string[];
+  testLabels?: string[];
   featureNames?: string[];
   executionTime: number;
   runId?: string;

--- a/lib/args/__init__.py
+++ b/lib/args/__init__.py
@@ -5,10 +5,6 @@ import json
 def merge_config(yaml_config, json_config):
     """Merge JSON config overrides into YAML config.
 
-    Only includes override keys that exist in the base YAML config.
-    This prevents passing incompatible params (e.g., max_iter from
-    HistGradientBoosting to GradientBoosting which uses n_estimators).
-
     Args:
         yaml_config: Base config from YAML file
         json_config: JSON string with overrides (snake_case keys)
@@ -25,10 +21,7 @@ def merge_config(yaml_config, json_config):
         return yaml_config
 
     merged = yaml_config.copy()
-    # Only apply overrides for keys that exist in the base config
-    for key, value in overrides.items():
-        if key in yaml_config:
-            merged[key] = value
+    merged.update(overrides)
 
     return merged
 

--- a/lib/dataset/render.py
+++ b/lib/dataset/render.py
@@ -143,46 +143,32 @@ class Render:
         cls.footer(filename)
 
     @classmethod
-    def clustering(cls, X, y, filename="clustering.png", max_samples=2000):
+    def clustering(cls, X, y, filename="clustering.png"):
         """Render MDS clustering visualization based on feature space.
 
         Args:
             X: Feature data
             y: Target labels
             filename: Output filename
-            max_samples: Maximum samples for MDS (MDS is O(n²) in memory)
         """
         from sklearn.preprocessing import StandardScaler
 
-        # Subsample if dataset is too large (MDS is O(n²) in memory)
-        if len(X) > max_samples:
-            np.random.seed(42)
-            indices = np.random.choice(len(X), max_samples, replace=False)
-            X_sample = X.iloc[indices]
-            y_sample = y.iloc[indices] if hasattr(y, 'iloc') else np.array(y)[indices]
-        else:
-            X_sample = X
-            y_sample = y
-
         # Standardize features and handle missing values
-        X_filled = X_sample.fillna(X_sample.mean())
+        X_filled = X.fillna(X.mean())
         X_scaled = StandardScaler().fit_transform(X_filled)
 
         # Apply MDS
-        mds = MDS(n_components=2, random_state=42, normalized_stress="auto", n_init=4, init="random")
+        mds = MDS(n_components=2, random_state=42, normalized_stress="auto")
         embedding = mds.fit_transform(X_scaled)
 
         # Plot
         cls.header(figsize=(10, 8))
-        scatter = plt.scatter(embedding[:, 0], embedding[:, 1], c=LabelEncoder().fit_transform(y_sample),
+        scatter = plt.scatter(embedding[:, 0], embedding[:, 1], c=LabelEncoder().fit_transform(y),
                              cmap="viridis", alpha=0.7, s=50)
         plt.colorbar(scatter, label="Class")
         plt.xlabel("MDS 1")
         plt.ylabel("MDS 2")
-        title = "Feature Space Clustering (MDS)"
-        if len(X) > max_samples:
-            title += f" - {max_samples}/{len(X)} samples"
-        cls.footer(filename, title=title)
+        cls.footer(filename, title="Feature Space Clustering (MDS)")
 
     @classmethod
     def tree(cls, clf, feature_names, class_names, filename="decision_tree.png"):
@@ -410,26 +396,17 @@ class Render:
         cls.footer(filename)
 
     @classmethod
-    def forest_proximity(cls, clf, X, filename="forest_proximity.png", max_samples=2000):
+    def forest_proximity(cls, clf, X, filename="forest_proximity.png"):
         """Render proximity matrix heatmap for random forest.
 
         Args:
             clf: Trained RandomForestClassifier
             X: Feature data
             filename: Output filename
-            max_samples: Maximum samples (proximity matrix is O(n²) in memory)
         """
-        # Subsample if dataset is too large
-        if len(X) > max_samples:
-            np.random.seed(42)
-            indices = np.random.choice(len(X), max_samples, replace=False)
-            X_sample = X.iloc[indices] if hasattr(X, 'iloc') else X[indices]
-        else:
-            X_sample = X
-
         # Compute proximity matrix
-        leaves = clf.apply(X_sample)
-        n_samples = len(X_sample)
+        leaves = clf.apply(X)
+        n_samples = len(X)
         proximity = np.zeros((n_samples, n_samples))
 
         for tree_leaves in leaves.T:
@@ -447,13 +424,10 @@ class Render:
                     xticklabels=False, yticklabels=False)
         plt.xlabel("Sample")
         plt.ylabel("Sample")
-        title = "Random Forest Proximity Matrix"
-        if len(X) > max_samples:
-            title += f" - {max_samples}/{len(X)} samples"
-        cls.footer(filename, title=title)
+        cls.footer(filename, title="Random Forest Proximity Matrix")
 
     @classmethod
-    def forest_clustering(cls, clf, X, y, filename="forest_clustering.png", max_samples=2000):
+    def forest_clustering(cls, clf, X, y, filename="forest_clustering.png"):
         """Render t-SNE clustering visualization based on proximity matrix.
 
         Args:
@@ -461,21 +435,10 @@ class Render:
             X: Feature data
             y: Target labels
             filename: Output filename
-            max_samples: Maximum samples (proximity matrix is O(n²) in memory)
         """
-        # Subsample if dataset is too large
-        if len(X) > max_samples:
-            np.random.seed(42)
-            indices = np.random.choice(len(X), max_samples, replace=False)
-            X_sample = X.iloc[indices] if hasattr(X, 'iloc') else X[indices]
-            y_sample = y.iloc[indices] if hasattr(y, 'iloc') else np.array(y)[indices]
-        else:
-            X_sample = X
-            y_sample = y
-
         # Compute proximity matrix
-        leaves = clf.apply(X_sample)
-        n_samples = len(X_sample)
+        leaves = clf.apply(X)
+        n_samples = len(X)
         proximity = np.zeros((n_samples, n_samples))
 
         for tree_leaves in leaves.T:
@@ -492,20 +455,17 @@ class Render:
         dissimilarity = 1 - proximity
 
         # Apply MDS on dissimilarity matrix
-        mds = MDS(n_components=2, dissimilarity="precomputed", random_state=42, normalized_stress="auto", n_init=4, init="random")
+        mds = MDS(n_components=2, dissimilarity="precomputed", random_state=42, normalized_stress="auto")
         embedding = mds.fit_transform(dissimilarity)
 
         # Plot
         cls.header(figsize=(10, 8))
-        scatter = plt.scatter(embedding[:, 0], embedding[:, 1], c=LabelEncoder().fit_transform(y_sample),
+        scatter = plt.scatter(embedding[:, 0], embedding[:, 1], c=LabelEncoder().fit_transform(y),
                              cmap="viridis", alpha=0.7, s=50)
         plt.colorbar(scatter, label="Class")
         plt.xlabel("MDS 1")
         plt.ylabel("MDS 2")
-        title = "Random Forest Clustering (MDS of Proximity)"
-        if len(X) > max_samples:
-            title += f" - {max_samples}/{len(X)} samples"
-        cls.footer(filename, title=title)
+        cls.footer(filename, title="Random Forest Clustering (MDS of Proximity)")
 
     @classmethod
     def gradient_forest_importance(cls, importances, feature_names, filename="gradient_forest_feature_importance.png"):

--- a/lib/model/report.py
+++ b/lib/model/report.py
@@ -68,10 +68,18 @@ def report(y_true, y_pred, json_output=False, model_info=None, params=None,
         if feature_importance is not None:
             summary["feature_importance"] = feature_importance
 
-        # Only include feature names (small), not the full dataset
-        # Dataset is already exported as CSV files by DataSource.export()
         if X_train is not None:
+            summary["train_data"] = X_train.to_dict(orient='records')
             summary["feature_names"] = X_train.columns.tolist()
+
+        if X_test is not None:
+            summary["test_data"] = X_test.to_dict(orient='records')
+
+        if y_train is not None:
+            summary["train_labels"] = y_train.tolist() if hasattr(y_train, 'tolist') else list(y_train)
+
+        if y_test is not None:
+            summary["test_labels"] = y_test.tolist() if hasattr(y_test, 'tolist') else list(y_test)
 
         # Convert any remaining NaN values to None
         summary = convert_nan_to_none(summary)

--- a/specs/Compare.md
+++ b/specs/Compare.md
@@ -188,7 +188,6 @@ The "Models to Compare" section header should include:
 - Button labeled "All models" appears next to the section title
   - When clicked, populates the models list with all available models from history
   - One entry per unique run in the history (avoids duplicates)
-  - Models are sorted by: model type, then named runs before unnamed runs, then alphabetically by name or ID
   - Button is disabled when history is loading or empty
 - Button labeled "Clear" appears next to "All models"
   - When clicked, removes all models from the compare list

--- a/specs/CompareHistory.md
+++ b/specs/CompareHistory.md
@@ -11,7 +11,7 @@ Enable compare runs to be persisted and browsable like model training runs. Each
 - History modal for compare runs shows:
   - Compare ID (timestamp)
   - Optional user-defined name
-  - List of compared model names/IDs (array format supporting arbitrary models)
+  - Model counts with labels and emojis (e.g., "4x Tree 🌳  2x Forest 🌲")
 
 ## Implementation Details
 
@@ -122,13 +122,15 @@ A "History" link in the top right corner of the Train/Compare tabs card:
 - In Train mode: opens TrainHistoryModal for the current model/dataset
 
 ### Compare History Modal
-A modal showing past comparison runs.
+A modal showing past comparison runs. Uses `fitContent` sizing to grow horizontally as names grow (similar to TrainHistoryModal).
 
 Display for each entry:
-- Compare ID (or name if set)
-- Timestamp (formatted as "X ago" or date)
-- Mask percentage and impute status badges
-- Model list showing each model type with its name or ID (array format)
+- Header row: Compare ID (or name if set), timestamp (formatted as "X ago" or date) - both use `whitespace-nowrap`
+- Badges row (if any params set): sequence/mask/impute badges on own line
+  - Sequence: shown as "sequence" badge (purple) only if sequence mode enabled
+  - Mask: shown as "mask: X%" badge (amber) only if mask > 0
+  - Impute: shown as "imputed" badge (blue) only if impute enabled
+- Model counts row: aggregated by type, count styled larger/bolder (e.g., "**4x** Tree 🌳  **2x** Forest 🌲"), each item uses `whitespace-nowrap`
 
 Actions:
 - Click to load the compare run (directly loads data and updates URL to `?compare_id=<id>`)
@@ -185,8 +187,11 @@ Add to the hook:
 
 #### CompareHistoryModal Component
 New component (`src/components/CompareHistoryModal.tsx`) showing list of past comparisons:
+- Modal uses `maxWidth="lg"` with `fitContent` and `minWidth={600}` to grow horizontally as names grow
+- Content is scrollable when exceeding max height
 - Receives runs from parent (fetched via `fetchCompareHistory`)
-- Each row shows: name/ID, timestamp, mask/impute badges, model names (array format)
+- Each row shows: name/ID, timestamp, mask/impute badges, model counts with emojis
+- Model counts: aggregated by type with larger/bolder count (e.g., "**4x** Tree 🌳  **2x** Forest 🌲")
 - Click row to load that compare run directly
 - Delete button per row
 

--- a/specs/frontend/CompareSequence.md
+++ b/specs/frontend/CompareSequence.md
@@ -4,34 +4,31 @@
 Add a "Sequence" mode to Compare that runs comparisons across multiple mask rates automatically. When Sequence is enabled, it disables manual Mask Rate and Impute controls and instead runs a full sequence of comparisons at predefined mask rates, testing both with and without imputation for each non-zero mask rate.
 
 ## Requirements
-- Add a "Sequence" checkbox in `CompareDatasetParams` next to the Impute checkbox
-- When Sequence is checked:
-  - Mask Rate slider is disabled (grayed out)
-  - Impute checkbox is disabled (grayed out)
+- Add a "Mode" dropdown next to "Dataset Parameters" heading with options: "Compare" and "Sequence"
+- When Mode is "Sequence":
+  - Mask Rate slider and Impute checkbox are hidden (not shown)
   - Comparison runs across mask rates: 0%, 10%, 20%, 30%, 40%, 50%, 60%
   - For each mask rate > 0, runs both with impute=false and impute=true
   - Generates a single comparison chart showing all models across all mask rates
-- When Sequence is unchecked (default):
-  - Current behavior preserved: manual Mask Rate and Impute controls work as before
-- Sequence checkbox state persisted to localStorage with other compare params
+- When Mode is "Compare" (default):
+  - Current behavior preserved: manual Mask Rate and Impute controls shown
+- Mode state persisted to localStorage with other compare params
 
 ## Layout
 
-**CompareDatasetParams with Sequence:**
+**CompareDatasetParams with Mode dropdown (Compare mode):**
 ```
 ┌─────────────────────────────────────────────────┐
-│ Dataset Params:                          [Reset]│
+│ Dataset Parameters  Mode: [Compare ▼]   [Reset]│
 │   Mask Rate: [====○====] 30%    ☑ Impute       │
-│   ☐ Sequence                                    │
 └─────────────────────────────────────────────────┘
 ```
 
-**When Sequence is checked:**
+**When Mode is Sequence:**
 ```
 ┌─────────────────────────────────────────────────┐
-│ Dataset Params:                          [Reset]│
-│   Mask Rate: [====○====] 30%    ☐ Impute       │  <- Both disabled/grayed
-│   ☑ Sequence                                    │
+│ Dataset Parameters  Mode: [Sequence ▼]  [Reset]│
+│   (Mask Rate and Impute hidden)                 │
 └─────────────────────────────────────────────────┘
 ```
 
@@ -39,18 +36,11 @@ Add a "Sequence" mode to Compare that runs comparisons across multiple mask rate
 
 ### CompareDatasetParams (Updated)
 - Add `sequence` boolean to params interface
-- Render Sequence checkbox below the Mask Rate / Impute row
-- Checkbox label: "Sequence"
-- When `sequence` is true:
-  - Pass `disabled={true}` to the Mask Rate slider
-  - Pass `disabled={true}` to the Impute checkbox
+- Render Mode dropdown next to "Dataset Parameters" heading
+- Dropdown options: "Compare", "Sequence"
+- When `sequence` is true (Mode is "Sequence"):
+  - Mask Rate slider and Impute checkbox are hidden entirely
 - Props change: `params.sequence` added
-
-### SequenceCheckbox (New Component)
-- Simple checkbox component for Sequence mode toggle
-- Props: `checked`, `onChange`, `disabled`
-- Location: `frontend/src/components/ui/SequenceCheckbox.tsx`
-- Styling consistent with ImputeCheckbox
 
 ## State Management
 
@@ -183,6 +173,8 @@ Uses `Render.compare_accuracy_impute()` style visualization:
 
 ### CompareResults (Sequence Mode)
 When sequence mode results are displayed:
+- Header shows "Sequence Comparison Results" with load models icon button (same as normal Compare Results)
+  - Load models icon loads all runtime models from the compare run into the compare form
 - Show the generated comparison chart image (`sequence_comparison.png`)
 - Chart shows accuracy trends across all mask rates for each model
 - Solid lines: without imputation
@@ -210,8 +202,8 @@ When sequence mode results are displayed:
 ```
 
 ## Implementation Details
-- Sequence checkbox should be visually consistent with Impute checkbox styling
-- When Reset button is clicked, `sequence` resets to `false`
+- Mode dropdown uses standard Select component
+- When Reset button is clicked, `sequence` resets to `false` (Mode returns to "Compare")
 - Compare button text remains "Compare Models" (no change for sequence mode)
 - Loading state shows spinner as usual during sequence comparison
 - Mask rates are fixed: [0, 10, 20, 30, 40, 50, 60] - not configurable by user


### PR DESCRIPTION
## Summary
- Remove redundant "Model Accuracies" label from CompareResults
- Display aggregated model counts with emojis in compare history modal (e.g., "4x Tree 🌳  2x Forest 🌲")
- Style count numbers larger and bolder for emphasis
- Add `minWidth` prop to Modal component
- Set compare history modal to min 600px width with fitContent sizing
- Move mask/impute badges to details row alongside model counts
- Vertically center delete button in history entries